### PR TITLE
内部でのみ使用する機能を実装する

### DIFF
--- a/__tests__/assert.spec.ts
+++ b/__tests__/assert.spec.ts
@@ -1,0 +1,13 @@
+import { assert } from '../src/internal/assert'
+
+describe('assert()', () => {
+  it('`void` を返す', () => {
+    expect(assert(true)).toBeUndefined()
+  })
+
+  it('例外を投げる', () => {
+    expect(() => assert(false, 'A DEFINED ERROR MESSAGE')).toThrowError(
+      'A DEFINED ERROR MESSAGE'
+    )
+  })
+})

--- a/__tests__/internal/getObjectTypeName.spec.ts
+++ b/__tests__/internal/getObjectTypeName.spec.ts
@@ -1,0 +1,119 @@
+import { getObjectTypeName } from '../../src/internal/getObjectTypeName'
+
+describe('getObjectTypeName()', () => {
+  it('`Object.prototype.toString.call()` を呼び出す', () => {
+    const spy = jest.spyOn(Object.prototype.toString as any, 'call') // eslint-disable-line @typescript-eslint/no-explicit-any
+    getObjectTypeName(123)
+    expect(spy).toHaveBeenCalledWith(123)
+    spy.mockRestore()
+  })
+
+  it('"[object Undefined]" を返す', () => {
+    expect(getObjectTypeName(undefined)).toBe('[object Undefined]')
+  })
+
+  it('"[object Null]" を返す', () => {
+    expect(getObjectTypeName(null)).toBe('[object Null]')
+  })
+
+  it('"[object Number]" を返す', () => {
+    expect(getObjectTypeName(NaN)).toBe('[object Number]')
+    expect(getObjectTypeName(123)).toBe('[object Number]')
+    expect(getObjectTypeName(new Number(123))).toBe('[object Number]') // eslint-disable-line no-new-wrappers
+  })
+
+  it('"[object BigInt]" を返す', () => {
+    // BigInt リテラルは tsc で `compilerOptions.target = esnext` に設定しなくては使用できないので現バージョンではサポートしない
+    // expect(getObjectTypeName(9007199254740991n)).toBe('[object BigInt]')
+    expect(getObjectTypeName(BigInt(9007199254740991))).toBe('[object BigInt]')
+    expect(getObjectTypeName(BigInt('9007199254740991'))).toBe(
+      '[object BigInt]'
+    )
+    expect(getObjectTypeName(BigInt('0x1fffffffffffff'))).toBe(
+      '[object BigInt]'
+    )
+    expect(
+      getObjectTypeName(
+        BigInt('0b11111111111111111111111111111111111111111111111111111')
+      )
+    ).toBe('[object BigInt]')
+  })
+
+  it('"[object String]" を返す', () => {
+    expect(getObjectTypeName('string')).toBe('[object String]')
+    expect(getObjectTypeName(new String('string'))).toBe('[object String]') // eslint-disable-line no-new-wrappers
+  })
+
+  it('"[object Boolean]" を返す', () => {
+    expect(getObjectTypeName(true)).toBe('[object Boolean]')
+    expect(getObjectTypeName(false)).toBe('[object Boolean]')
+  })
+
+  it('"[object Date]" を返す', () => {
+    expect(getObjectTypeName(new Date('2020-10-10T12:34:56.789+09:00'))).toBe(
+      '[object Date]'
+    )
+  })
+
+  it('"[object RegExp]" を返す', () => {
+    expect(getObjectTypeName(/^.+$/)).toBe('[object RegExp]')
+    expect(getObjectTypeName(new RegExp('^.+$'))).toBe('[object RegExp]')
+  })
+
+  it('"[object Array]" を返す', () => {
+    expect(getObjectTypeName([0, 1, 2])).toBe('[object Array]')
+  })
+
+  it('"[object Object]" を返す', () => {
+    expect(getObjectTypeName({ key: 'value' })).toBe('[object Object]')
+  })
+
+  it('"[object Promise]" を返す', () => {
+    expect(getObjectTypeName(new Promise(resolve => resolve()))).toBe(
+      '[object Promise]'
+    )
+    const asyncFunc = async (): Promise<void> => undefined
+    expect(getObjectTypeName(asyncFunc())).toBe('[object Promise]')
+  })
+
+  it('"[object Symbol]" を返す', () => {
+    expect(getObjectTypeName(Symbol('symbol'))).toBe('[object Symbol]')
+  })
+
+  it('"[object Map]" を返す', () => {
+    expect(getObjectTypeName(new Map([['key', 'value']]))).toBe('[object Map]')
+  })
+
+  it('"[object Set]" を返す', () => {
+    expect(getObjectTypeName(new Set(['value']))).toBe('[object Set]')
+  })
+
+  it('"[object WeakMap]" を返す', () => {
+    expect(getObjectTypeName(new WeakMap())).toBe('[object WeakMap]')
+  })
+
+  it('"[object WeakSet]" を返す', () => {
+    expect(getObjectTypeName(new WeakSet())).toBe('[object WeakSet]')
+  })
+
+  it('"[object Function]" を返す', () => {
+    expect(
+      getObjectTypeName(function func() {
+        return undefined
+      })
+    ).toBe('[object Function]')
+    expect(getObjectTypeName(() => undefined)).toBe('[object Function]')
+  })
+
+  it('"[object GeneratorFunction]" を返す', () => {
+    expect(
+      getObjectTypeName(function* func() {
+        return undefined
+      })
+    ).toBe('[object GeneratorFunction]')
+  })
+
+  it('"[object Error]" を返す', () => {
+    expect(getObjectTypeName(new Error())).toBe('[object Error]')
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/type-assertions",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/type-assertions",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "Type assertion utilities.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -1,4 +1,5 @@
 import Checks from './checks'
+import { assert } from './internal/assert'
 
 /**
  * 型アサートAPI
@@ -9,13 +10,10 @@ export const Asserts = {
   /**
    * 値が数値かアサートする
    * @param value
-   * @throw {TypeError} 値が数値でない
-   * @todo エラー生成などは内部機能で共通化する
+   * @throw `value` が数値でない
    */
   isNumber(value: any): asserts value is number {
-    if (!Checks.isNumber(value)) {
-      throw new TypeError('value is not a number')
-    }
+    return assert(Checks.isNumber(value), 'value is not a number')
   }
 }
 

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -1,3 +1,5 @@
+import { getObjectTypeName } from './internal/getObjectTypeName'
+
 /**
  * 型チェックAPI
  * @description 値が指定の方であるか否かを `boolean` で返す
@@ -8,10 +10,9 @@ export const Checks = {
    * 値が数値か否かを返す
    * @param value
    * @todo `value` を `unknown` 型とする
-   * @todo `typeof` を使わない実装にする
    */
   isNumber(value: any): value is number {
-    return typeof value === 'number'
+    return getObjectTypeName(value) === '[object Number]'
   }
 }
 

--- a/src/internal/assert.ts
+++ b/src/internal/assert.ts
@@ -1,0 +1,15 @@
+/**
+ * @hidden 指定の条件でアサートする
+ * @see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions
+ * @param condition
+ * @param errorMessage
+ * @throw `condition` が Falthy ならば `errorMessage` を内容とする例外を投げる
+ */
+export function assert(
+  condition: unknown,
+  errorMessage?: string
+): asserts condition {
+  if (!condition) {
+    throw new Error(errorMessage)
+  }
+}

--- a/src/internal/getObjectTypeName.ts
+++ b/src/internal/getObjectTypeName.ts
@@ -1,0 +1,8 @@
+/**
+ * @hidden オブジェクトの型名を文字列で返す
+ * @see https://qiita.com/amamamaou/items/ef0b797156b324bb4ef3#objectprototypetostringcall-%E3%82%92%E4%BD%BF%E3%81%86
+ * @param value 型名を得たいオブジェクト
+ */
+export function getObjectTypeName(value: unknown): string {
+  return Object.prototype.toString.call(value)
+}


### PR DESCRIPTION
#7 
ライブラリ内部でのみ使用する機能を実装します。

- [x] オブジェクトの型名を文字列で取得する関数
- [x] 汎用のアサーション関数
