### PR TITLE
オブジェクトの型名を文字列で取得する機能を実装する

### DIFF
--- a/__tests__/internal/getObjectTypeName.spec.ts
+++ b/__tests__/internal/getObjectTypeName.spec.ts
@@ -18,37 +18,22 @@ describe('getObjectTypeName()', () => {
 
   it('"[object Number]" を返す', () => {
     expect(getObjectTypeName(NaN)).toBe('[object Number]')
-  })
-
-  it('"[object Number]" を返す', () => {
     expect(getObjectTypeName(123)).toBe('[object Number]')
-  })
-
-  it('"[object Number]" を返す', () => {
     expect(getObjectTypeName(new Number(123))).toBe('[object Number]') // eslint-disable-line no-new-wrappers
   })
 
   it('"[object String]" を返す', () => {
     expect(getObjectTypeName('string')).toBe('[object String]')
-  })
-
-  it('"[object String]" を返す', () => {
     expect(getObjectTypeName(new String('string'))).toBe('[object String]') // eslint-disable-line no-new-wrappers
   })
 
   it('"[object Boolean]" を返す', () => {
     expect(getObjectTypeName(true)).toBe('[object Boolean]')
-  })
-
-  it('"[object Boolean]" を返す', () => {
     expect(getObjectTypeName(false)).toBe('[object Boolean]')
   })
 
   it('"[object RegExp]" を返す', () => {
     expect(getObjectTypeName(/^.+$/)).toBe('[object RegExp]')
-  })
-
-  it('"[object RegExp]" を返す', () => {
     expect(getObjectTypeName(new RegExp('^.+$'))).toBe('[object RegExp]')
   })
 
@@ -78,9 +63,6 @@ describe('getObjectTypeName()', () => {
         return undefined
       })
     ).toBe('[object Function]')
-  })
-
-  it('"[object Function]" を返す', () => {
     expect(getObjectTypeName(() => undefined)).toBe('[object Function]')
   })
 

--- a/__tests__/internal/getObjectTypeName.spec.ts
+++ b/__tests__/internal/getObjectTypeName.spec.ts
@@ -93,6 +93,10 @@ describe('getObjectTypeName()', () => {
     expect(getObjectTypeName(new WeakMap())).toBe('[object WeakMap]')
   })
 
+  it('"[object WeakSet]" を返す', () => {
+    expect(getObjectTypeName(new WeakSet())).toBe('[object WeakSet]')
+  })
+
   it('"[object Function]" を返す', () => {
     expect(
       getObjectTypeName(function func() {

--- a/__tests__/internal/getObjectTypeName.spec.ts
+++ b/__tests__/internal/getObjectTypeName.spec.ts
@@ -32,6 +32,12 @@ describe('getObjectTypeName()', () => {
     expect(getObjectTypeName(false)).toBe('[object Boolean]')
   })
 
+  it('"[object Date]" を返す', () => {
+    expect(getObjectTypeName(new Date('2020-10-10T12:34:56.789+09:00'))).toBe(
+      '[object Date]'
+    )
+  })
+
   it('"[object RegExp]" を返す', () => {
     expect(getObjectTypeName(/^.+$/)).toBe('[object RegExp]')
     expect(getObjectTypeName(new RegExp('^.+$'))).toBe('[object RegExp]')

--- a/__tests__/internal/getObjectTypeName.spec.ts
+++ b/__tests__/internal/getObjectTypeName.spec.ts
@@ -89,6 +89,10 @@ describe('getObjectTypeName()', () => {
     expect(getObjectTypeName(new Set(['value']))).toBe('[object Set]')
   })
 
+  it('"[object WeakMap]" を返す', () => {
+    expect(getObjectTypeName(new WeakMap())).toBe('[object WeakMap]')
+  })
+
   it('"[object Function]" を返す', () => {
     expect(
       getObjectTypeName(function func() {

--- a/__tests__/internal/getObjectTypeName.spec.ts
+++ b/__tests__/internal/getObjectTypeName.spec.ts
@@ -1,4 +1,5 @@
 import { getObjectTypeName } from '../../src/internal/getObjectTypeName'
+import { resolve } from 'path'
 
 describe('getObjectTypeName()', () => {
   it('`Object.prototype.toString.call()` を呼び出す', () => {
@@ -49,6 +50,14 @@ describe('getObjectTypeName()', () => {
 
   it('"[object Object]" を返す', () => {
     expect(getObjectTypeName({ key: 'value' })).toBe('[object Object]')
+  })
+
+  it('"[object Promise]" を返す', () => {
+    expect(getObjectTypeName(new Promise(resolve => resolve()))).toBe(
+      '[object Promise]'
+    )
+    const asyncFunc = async () => undefined
+    expect(getObjectTypeName(asyncFunc())).toBe('[object Promise]')
   })
 
   it('"[object Symbol]" を返す', () => {

--- a/__tests__/internal/getObjectTypeName.spec.ts
+++ b/__tests__/internal/getObjectTypeName.spec.ts
@@ -1,5 +1,4 @@
 import { getObjectTypeName } from '../../src/internal/getObjectTypeName'
-import { resolve } from 'path'
 
 describe('getObjectTypeName()', () => {
   it('`Object.prototype.toString.call()` を呼び出す', () => {
@@ -73,7 +72,7 @@ describe('getObjectTypeName()', () => {
     expect(getObjectTypeName(new Promise(resolve => resolve()))).toBe(
       '[object Promise]'
     )
-    const asyncFunc = async () => undefined
+    const asyncFunc = async (): Promise<void> => undefined
     expect(getObjectTypeName(asyncFunc())).toBe('[object Promise]')
   })
 

--- a/__tests__/internal/getObjectTypeName.spec.ts
+++ b/__tests__/internal/getObjectTypeName.spec.ts
@@ -1,0 +1,10 @@
+import { getObjectTypeName } from '../../src/internal/getObjectTypeName'
+
+describe('getObjectTypeName()', () => {
+  it('`Object.prototype.toString.call()` を呼び出す', () => {
+    const spy = jest.spyOn(Object.prototype.toString as any, 'call')
+    getObjectTypeName(123)
+    expect(spy).toHaveBeenCalledWith(123)
+    spy.mockRestore()
+  })
+})

--- a/__tests__/internal/getObjectTypeName.spec.ts
+++ b/__tests__/internal/getObjectTypeName.spec.ts
@@ -23,6 +23,23 @@ describe('getObjectTypeName()', () => {
     expect(getObjectTypeName(new Number(123))).toBe('[object Number]') // eslint-disable-line no-new-wrappers
   })
 
+  it('"[object BigInt]" を返す', () => {
+    // BigInt リテラルは tsc で `compilerOptions.target = esnext` に設定しなくては使用できないので現バージョンではサポートしない
+    // expect(getObjectTypeName(9007199254740991n)).toBe('[object BigInt]')
+    expect(getObjectTypeName(BigInt(9007199254740991))).toBe('[object BigInt]')
+    expect(getObjectTypeName(BigInt('9007199254740991'))).toBe(
+      '[object BigInt]'
+    )
+    expect(getObjectTypeName(BigInt('0x1fffffffffffff'))).toBe(
+      '[object BigInt]'
+    )
+    expect(
+      getObjectTypeName(
+        BigInt('0b11111111111111111111111111111111111111111111111111111')
+      )
+    ).toBe('[object BigInt]')
+  })
+
   it('"[object String]" を返す', () => {
     expect(getObjectTypeName('string')).toBe('[object String]')
     expect(getObjectTypeName(new String('string'))).toBe('[object String]') // eslint-disable-line no-new-wrappers

--- a/__tests__/internal/getObjectTypeName.spec.ts
+++ b/__tests__/internal/getObjectTypeName.spec.ts
@@ -113,4 +113,8 @@ describe('getObjectTypeName()', () => {
       })
     ).toBe('[object GeneratorFunction]')
   })
+
+  it('"[object Error]" を返す', () => {
+    expect(getObjectTypeName(new Error())).toBe('[object Error]')
+  })
 })

--- a/__tests__/internal/getObjectTypeName.spec.ts
+++ b/__tests__/internal/getObjectTypeName.spec.ts
@@ -2,9 +2,93 @@ import { getObjectTypeName } from '../../src/internal/getObjectTypeName'
 
 describe('getObjectTypeName()', () => {
   it('`Object.prototype.toString.call()` を呼び出す', () => {
-    const spy = jest.spyOn(Object.prototype.toString as any, 'call')
+    const spy = jest.spyOn(Object.prototype.toString as any, 'call') // eslint-disable-line @typescript-eslint/no-explicit-any
     getObjectTypeName(123)
     expect(spy).toHaveBeenCalledWith(123)
     spy.mockRestore()
+  })
+
+  it('"[object Undefined]" を返す', () => {
+    expect(getObjectTypeName(undefined)).toBe('[object Undefined]')
+  })
+
+  it('"[object Null]" を返す', () => {
+    expect(getObjectTypeName(null)).toBe('[object Null]')
+  })
+
+  it('"[object Number]" を返す', () => {
+    expect(getObjectTypeName(NaN)).toBe('[object Number]')
+  })
+
+  it('"[object Number]" を返す', () => {
+    expect(getObjectTypeName(123)).toBe('[object Number]')
+  })
+
+  it('"[object Number]" を返す', () => {
+    expect(getObjectTypeName(new Number(123))).toBe('[object Number]') // eslint-disable-line no-new-wrappers
+  })
+
+  it('"[object String]" を返す', () => {
+    expect(getObjectTypeName('string')).toBe('[object String]')
+  })
+
+  it('"[object String]" を返す', () => {
+    expect(getObjectTypeName(new String('string'))).toBe('[object String]') // eslint-disable-line no-new-wrappers
+  })
+
+  it('"[object Boolean]" を返す', () => {
+    expect(getObjectTypeName(true)).toBe('[object Boolean]')
+  })
+
+  it('"[object Boolean]" を返す', () => {
+    expect(getObjectTypeName(false)).toBe('[object Boolean]')
+  })
+
+  it('"[object RegExp]" を返す', () => {
+    expect(getObjectTypeName(/^.+$/)).toBe('[object RegExp]')
+  })
+
+  it('"[object RegExp]" を返す', () => {
+    expect(getObjectTypeName(new RegExp('^.+$'))).toBe('[object RegExp]')
+  })
+
+  it('"[object Array]" を返す', () => {
+    expect(getObjectTypeName([0, 1, 2])).toBe('[object Array]')
+  })
+
+  it('"[object Object]" を返す', () => {
+    expect(getObjectTypeName({ key: 'value' })).toBe('[object Object]')
+  })
+
+  it('"[object Symbol]" を返す', () => {
+    expect(getObjectTypeName(Symbol('symbol'))).toBe('[object Symbol]')
+  })
+
+  it('"[object Map]" を返す', () => {
+    expect(getObjectTypeName(new Map([['key', 'value']]))).toBe('[object Map]')
+  })
+
+  it('"[object Set]" を返す', () => {
+    expect(getObjectTypeName(new Set(['value']))).toBe('[object Set]')
+  })
+
+  it('"[object Function]" を返す', () => {
+    expect(
+      getObjectTypeName(function func() {
+        return undefined
+      })
+    ).toBe('[object Function]')
+  })
+
+  it('"[object Function]" を返す', () => {
+    expect(getObjectTypeName(() => undefined)).toBe('[object Function]')
+  })
+
+  it('"[object GeneratorFunction]" を返す', () => {
+    expect(
+      getObjectTypeName(function* func() {
+        return undefined
+      })
+    ).toBe('[object GeneratorFunction]')
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/type-assertions",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/type-assertions",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "Type assertion utilities.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -1,3 +1,5 @@
+import { getObjectTypeName } from './internal/getObjectTypeName'
+
 /**
  * 型チェックAPI
  * @description 値が指定の方であるか否かを `boolean` で返す
@@ -8,10 +10,9 @@ export const Checks = {
    * 値が数値か否かを返す
    * @param value
    * @todo `value` を `unknown` 型とする
-   * @todo `typeof` を使わない実装にする
    */
   isNumber(value: any): value is number {
-    return typeof value === 'number'
+    return getObjectTypeName(value) === '[object Number]'
   }
 }
 

--- a/src/internal/getObjectTypeName.ts
+++ b/src/internal/getObjectTypeName.ts
@@ -1,5 +1,8 @@
 /**
  * @hidden オブジェクトの型名を文字列で返す
+ * @see https://qiita.com/amamamaou/items/ef0b797156b324bb4ef3#objectprototypetostringcall-%E3%82%92%E4%BD%BF%E3%81%86
  * @param value 型名を得たいオブジェクト
  */
-export function getObjectTypeName(value: unknown) {}
+export function getObjectTypeName(value: unknown): string {
+  return Object.prototype.toString.call(value)
+}

--- a/src/internal/getObjectTypeName.ts
+++ b/src/internal/getObjectTypeName.ts
@@ -1,0 +1,5 @@
+/**
+ * @hidden オブジェクトの型名を文字列で返す
+ * @param value 型名を得たいオブジェクト
+ */
+export function getObjectTypeName(value: unknown) {}


### PR DESCRIPTION
#10 
`typeof` 演算子では厳密な型判定ができないため、オブジェクトの型名を文字列で取得するための関数を実装します。
Checks API では主にここで実装する関数で型の判定を行う想定。

`Object.prototype.toString.call()` を使用することで機能を実現します。
→ 参考: [JavaScriptの型などの判定いろいろ - Object.prototype.toString.call() を使う](https://qiita.com/amamamaou/items/ef0b797156b324bb4ef3#objectprototypetostringcall-%E3%82%92%E4%BD%BF%E3%81%86)