### PR TITLE
汎用のアサーション関数を実装する

### DIFF
--- a/__tests__/assert.spec.ts
+++ b/__tests__/assert.spec.ts
@@ -1,0 +1,7 @@
+import { assert } from '../src/internal/assert'
+
+describe('assert()', () => {
+  it('`void` を返す', () => {
+    expect(assert(true)).toBeUndefined()
+  })
+})

--- a/__tests__/assert.spec.ts
+++ b/__tests__/assert.spec.ts
@@ -4,4 +4,10 @@ describe('assert()', () => {
   it('`void` を返す', () => {
     expect(assert(true)).toBeUndefined()
   })
+
+  it('例外を投げる', () => {
+    expect(() => assert(false, 'A DEFINED ERROR MESSAGE')).toThrowError(
+      'A DEFINED ERROR MESSAGE'
+    )
+  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/type-assertions",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/type-assertions",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "Type assertion utilities.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -1,4 +1,5 @@
 import Checks from './checks'
+import { assert } from './internal/assert'
 
 /**
  * 型アサートAPI
@@ -10,12 +11,9 @@ export const Asserts = {
    * 値が数値かアサートする
    * @param value
    * @throw {TypeError} 値が数値でない
-   * @todo エラー生成などは内部機能で共通化する
    */
   isNumber(value: any): asserts value is number {
-    if (!Checks.isNumber(value)) {
-      throw new TypeError('value is not a number')
-    }
+    return assert(Checks.isNumber(value), 'value is not a number')
   }
 }
 

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -10,7 +10,7 @@ export const Asserts = {
   /**
    * 値が数値かアサートする
    * @param value
-   * @throw {TypeError} 値が数値でない
+   * @throw `value` が数値でない
    */
   isNumber(value: any): asserts value is number {
     return assert(Checks.isNumber(value), 'value is not a number')

--- a/src/internal/assert.ts
+++ b/src/internal/assert.ts
@@ -1,5 +1,6 @@
 /**
  * @hidden 指定の条件でアサートする
+ * @see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions
  * @param condition
  * @param errorMessage
  * @throw `condition` が Falthy ならば `errorMessage` を内容とする例外を投げる

--- a/src/internal/assert.ts
+++ b/src/internal/assert.ts
@@ -2,8 +2,13 @@
  * @hidden 指定の条件でアサートする
  * @param condition
  * @param errorMessage
+ * @throw `condition` が Falthy ならば `errorMessage` を内容とする例外を投げる
  */
 export function assert(
   condition: unknown,
   errorMessage?: string
-): asserts condition {}
+): asserts condition {
+  if (!condition) {
+    throw new Error(errorMessage)
+  }
+}

--- a/src/internal/assert.ts
+++ b/src/internal/assert.ts
@@ -1,0 +1,9 @@
+/**
+ * @hidden 指定の条件でアサートする
+ * @param condition
+ * @param errorMessage
+ */
+export function assert(
+  condition: unknown,
+  errorMessage?: string
+): asserts condition {}


### PR DESCRIPTION
#10 
Asserts API で汎用的に呼び出すアサーション関数を実装しました。
`asserts condition` 述語で定義して、Falthy な値が渡されると例外を投げる実装です。

基本的には TypeScript 3.7 のリリースノートに示されている実装をほぼそのまま利用しています。
→ 参考: [TypeScript 3.7- Assertion Functions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions)