### PR TITLE
`isStrictNumber()` を実装する

### DIFF
--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -127,4 +127,34 @@ describe('Asserts API', () => {
       expect(checksAPISpy).toHaveReturnedWith(false)
     })
   })
+
+  describe('isStrictNumber()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isStrictNumber)
+      checksAPISpy = jest.spyOn(Checks, 'isStrictNumber')
+    })
+
+    beforeEach(() => {
+      checksAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      checksAPISpy.mockRestore()
+    })
+
+    it('`Checks.isStrictNumber()` を呼び出す', () => {
+      assertion(123)
+      expect(checksAPISpy).toHaveBeenCalledWith(123)
+    })
+
+    it('`void` を返す', () => {
+      expect(assertion(123)).toBeUndefined()
+      expect(checksAPISpy).toHaveReturnedWith(true)
+    })
+
+    it('例外を投げる', () => {
+      expect(() => assertion(NaN)).toThrowError('value is not a strict number')
+      expect(checksAPISpy).toHaveReturnedWith(false)
+    })
+  })
 })

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -100,4 +100,31 @@ describe('Checks API', () => {
       expect(Checks.isNumber('123')).toBe(false)
     })
   })
+
+  describe('isStrictNumber()', () => {
+    it('`Checks.isNumber() を呼び出す`', () => {
+      const isNumberSpy = jest.spyOn(Checks, 'isNumber')
+      Checks.isStrictNumber(123)
+      expect(isNumberSpy).toBeCalledWith(123)
+      isNumberSpy.mockRestore()
+    })
+
+    it('`Checks.isNaN() を呼び出す`', () => {
+      const isNaNSpy = jest.spyOn(Checks, 'isNaN')
+      Checks.isStrictNumber(123)
+      expect(isNaNSpy).toBeCalledWith(123)
+      isNaNSpy.mockRestore()
+    })
+
+    it('`true` を返す', () => {
+      expect(Checks.isStrictNumber(123)).toBe(true)
+      expect(Checks.isStrictNumber(new Number(123))).toBe(true) // eslint-disable-line no-new-wrappers
+    })
+
+    it('`false` を返す', () => {
+      expect(Checks.isStrictNumber(NaN)).toBe(false)
+      expect(Checks.isStrictNumber(null)).toBe(false)
+      expect(Checks.isStrictNumber('123')).toBe(false)
+    })
+  })
 })

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -49,7 +49,7 @@ export const Asserts = {
    * @throw `value` が厳密に数値でない
    */
   isStrictNumber(value: unknown): asserts value is number {
-    return
+    return assert(Checks.isStrictNumber(value), 'value is not a strict number')
   }
 }
 

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -40,6 +40,16 @@ export const Asserts = {
    */
   isNumber(value: any): asserts value is number {
     return assert(Checks.isNumber(value), 'value is not a number')
+  },
+
+  /**
+   * 値が厳密に数値かアサートする
+   * @description `NaN` を例外とする
+   * @param value
+   * @throw `value` が厳密に数値でない
+   */
+  isStrictNumber(value: unknown): asserts value is number {
+    return
   }
 }
 

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -47,7 +47,7 @@ export const Checks = {
    * @param value
    */
   isStrictNumber(value: unknown): value is number {
-    return true
+    return Checks.isNumber(value) && !Checks.isNaN(value)
   }
 }
 

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -39,6 +39,15 @@ export const Checks = {
    */
   isNumber(value: unknown): value is number {
     return getObjectTypeName(value) === '[object Number]'
+  },
+
+  /**
+   * 値が厳密に数値か否かを返す
+   * @description `NaN` を `false` とする
+   * @param value
+   */
+  isStrictNumber(value: unknown): value is number {
+    return true
   }
 }
 


### PR DESCRIPTION
#13 

`isStrictNumber()` を実装します。

## 仕様
- `isNumber()` / `isNaN()` ( #19 ) を用いる
- `isStrictNumber(123) // => true`
- `isStrictNumber(NaN) // => false`
