### PR TITLE
`isArray()` を実装する

### DIFF
--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -8,6 +8,36 @@ describe('Asserts API', () => {
   let assertion: ReturnType<typeof createAssertion>
   let checksAPISpy: jest.SpyInstance
 
+  describe('isArray()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isArray)
+      checksAPISpy = jest.spyOn(Checks, 'isArray')
+    })
+
+    beforeEach(() => {
+      checksAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      checksAPISpy.mockRestore()
+    })
+
+    it('`Chekcs.isArray()` を呼び出す', () => {
+      assertion([])
+      expect(checksAPISpy).toHaveBeenCalledWith([])
+    })
+
+    it('`void` を返す', () => {
+      expect(assertion([])).toBeUndefined()
+      expect(checksAPISpy).toHaveReturnedWith(true)
+    })
+
+    it('例外を投げる。', () => {
+      expect(() => assertion(null)).toThrowError('value is not an array')
+      expect(checksAPISpy).toHaveReturnedWith(false)
+    })
+  })
+
   describe('isNumber()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isNumber)

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -14,6 +14,25 @@ describe('Checks API', () => {
     getObjectTypeNameSpy.mockRestore()
   })
 
+  describe('isArray()', () => {
+    it('`Array.isArray() を呼び出す', () => {
+      const isArraySpy = jest.spyOn(Array, 'isArray')
+      Checks.isArray([])
+      expect(isArraySpy).toBeCalledWith([])
+      isArraySpy.mockRestore()
+    })
+
+    it('`true` を返す', () => {
+      expect(Checks.isArray([])).toBe(true)
+      expect(Checks.isArray(new Array())).toBe(true)
+    })
+
+    it('`false` を返す', () => {
+      expect(Checks.isArray(null)).toBe(false)
+      expect(Checks.isArray(new Set())).toBe(false)
+    })
+  })
+
   describe('isNumber()', () => {
     it('`getObjectTypeName()` を呼び出す', () => {
       Checks.isNumber(123)

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -12,7 +12,7 @@ export const Asserts = {
    * @param value
    */
   isArray<T>(value: unknown): asserts value is T[] {
-    return
+    return assert(Checks.isArray<T>(value), 'value is not an array')
   },
 
   /**

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -8,6 +8,14 @@ import { assert } from './internal/assert'
  */
 export const Asserts = {
   /**
+   * 値が配列かアサートする
+   * @param value
+   */
+  isArray<T>(value: unknown): asserts value is T[] {
+    return
+  },
+
+  /**
    * 値が数値かアサートする
    * @description `NaN` を許容する
    * @param value

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -8,10 +8,11 @@ import { getObjectTypeName } from './internal/getObjectTypeName'
 export const Checks = {
   /**
    * 値が配列か否かを返す
+   * @alias `Array.isArray()`
    * @param value
    */
   isArray<T>(value: unknown): value is T[] {
-    return true
+    return Array.isArray(value)
   },
 
   /**

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -7,6 +7,14 @@ import { getObjectTypeName } from './internal/getObjectTypeName'
  */
 export const Checks = {
   /**
+   * 値が配列か否かを返す
+   * @param value
+   */
+  isArray<T>(value: unknown): value is T[] {
+    return true
+  },
+
+  /**
    * 値が数値か否かを返す
    * @description `NaN` を `true` とする
    * @param value


### PR DESCRIPTION
#13 

`isArray()` を実装します。

## 仕様
- `Array.isArray()` を用いる
- `isArray([]) // => true`
- `isArray(null) // => false`
