### PR TITLE
`isBigInt()` を実装する

### DIFF
--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -8,6 +8,36 @@ describe('Asserts API', () => {
   let assertion: ReturnType<typeof createAssertion>
   let checksAPISpy: jest.SpyInstance
 
+  describe('isBigInt()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isBigInt)
+      checksAPISpy = jest.spyOn(Checks, 'isBigInt')
+    })
+
+    beforeEach(() => {
+      checksAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      checksAPISpy.mockRestore()
+    })
+
+    it('`Checks.isNumber()` を呼び出す', () => {
+      assertion(BigInt(9007199254740991))
+      expect(checksAPISpy).toHaveBeenCalledWith(BigInt(9007199254740991))
+    })
+
+    it('`void` を返す', () => {
+      expect(assertion(BigInt(9007199254740991))).toBeUndefined()
+      expect(checksAPISpy).toHaveReturnedWith(true)
+    })
+
+    it('例外を投げる', () => {
+      expect(() => assertion(null)).toThrowError('value is not a bigint')
+      expect(checksAPISpy).toHaveReturnedWith(false)
+    })
+  })
+
   describe('isNumber()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isNumber)

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -14,6 +14,30 @@ describe('Checks API', () => {
     getObjectTypeNameSpy.mockRestore()
   })
 
+  describe('isBigInt()', () => {
+    it('`getObjectTypeName()` を呼び出す', () => {
+      Checks.isBigInt(BigInt(9007199254740991))
+      expect(getObjectTypeNameSpy).toBeCalledWith(BigInt(9007199254740991))
+    })
+
+    it('`true` を返す', () => {
+      expect(Checks.isBigInt(BigInt(9007199254740991))).toBe(true)
+      expect(Checks.isBigInt(BigInt('9007199254740991'))).toBe(true)
+      expect(Checks.isBigInt(BigInt('0x1fffffffffffff'))).toBe(true)
+      expect(
+        Checks.isBigInt(
+          BigInt('0b11111111111111111111111111111111111111111111111111111')
+        )
+      ).toBe(true)
+    })
+
+    it('`false` を返す', () => {
+      expect(Checks.isBigInt(123)).toBe(false)
+      expect(Checks.isBigInt(NaN)).toBe(false)
+      expect(Checks.isBigInt(null)).toBe(false)
+    })
+  })
+
   describe('isNumber()', () => {
     it('`getObjectTypeName()` を呼び出す', () => {
       Checks.isNumber(123)

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -8,6 +8,15 @@ import { assert } from './internal/assert'
  */
 export const Asserts = {
   /**
+   * 値がBigIntかアサートする
+   * @param value
+   * @throw `value` がBigIntでない
+   */
+  isBigInt(value: unknown): asserts value is bigint {
+    return
+  },
+
+  /**
    * 値が数値かアサートする
    * @description `NaN` を許容する
    * @param value

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -13,7 +13,7 @@ export const Asserts = {
    * @throw `value` がBigIntでない
    */
   isBigInt(value: unknown): asserts value is bigint {
-    return
+    return assert(Checks.isBigInt(value), 'value is not a bigint')
   },
 
   /**

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -11,7 +11,7 @@ export const Checks = {
    * @param value
    */
   isBigInt(value: unknown): value is bigint {
-    return true
+    return getObjectTypeName(value) === '[object BigInt]'
   },
 
   /**

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -7,6 +7,14 @@ import { getObjectTypeName } from './internal/getObjectTypeName'
  */
 export const Checks = {
   /**
+   * 値がBigIntか否かを返す
+   * @param value
+   */
+  isBigInt(value: unknown): value is bigint {
+    return true
+  },
+
+  /**
    * 値が数値か否かを返す
    * @description `NaN` を `true` とする
    * @param value


### PR DESCRIPTION
#13 

`isNaN()` を実装します。

## 仕様

### `true`

- `isBigInt(BigInt(9007199254740991))`
- `isBigInt(BigInt('9007199254740991'))`
- `isBigInt(BigInt('0x1fffffffffffff'))`
- `isBigInt(BigInt('0b11111111111111111111111111111111111111111111111111111'))`

### `false`

- `isBigInt(123)`
- `isBigInt(NaN)`
- `isBigInt(Null)`
