### PR TITLE
開発用のnpm-scriptsを設定する

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint src/**/*.ts __tests__/**/*.ts",
     "lint:fix": "npm run lint -- --fix",
     "prepublishOnly": "npm run lint && npm run test && npm run build",
-    "test": "jest"
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint src/**/*.ts __tests__/**/*.ts",
     "lint:fix": "npm run lint -- --fix",
     "prepublishOnly": "npm run lint && npm run test && npm run build",
+    "start": "npm run test:watch",
     "test": "jest",
     "test:watch": "jest --watch"
   },


### PR DESCRIPTION
テスト駆動開発のためのnpm-scriptsを設定します。
開発時に `npm start` することでテストしながらコードを書けるようにします。

- `test:watch`: `jest --watch`
-  `start`: `npm run test:watch`

確認お願いします。
