### PR TITLE
`isDate()` を実装する

### DIFF
--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -98,6 +98,38 @@ describe('Asserts API', () => {
     })
   })
 
+  describe('isDate()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isDate)
+      checksAPISpy = jest.spyOn(Checks, 'isDate')
+    })
+
+    beforeEach(() => {
+      checksAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      checksAPISpy.mockRestore()
+    })
+
+    const date = new Date('2020-10-10')
+
+    it('`Checks.isDate()` を呼び出す', () => {
+      assertion(date)
+      expect(checksAPISpy).toHaveBeenCalledWith(date)
+    })
+
+    it('`void` を返す', () => {
+      expect(assertion(date)).toBeUndefined()
+      expect(checksAPISpy).toHaveReturnedWith(true)
+    })
+
+    it('例外を投げる', () => {
+      expect(() => assertion(null)).toThrowError('value is not a Date')
+      expect(checksAPISpy).toHaveReturnedWith(false)
+    })
+  })
+
   describe('isNaN()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isNaN)

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -79,6 +79,23 @@ describe('Checks API', () => {
     })
   })
 
+  describe('isDate()', () => {
+    it('`getObjectTypeName()` を呼び出す', () => {
+      const date = new Date('2020-10-10')
+      Checks.isDate(date)
+      expect(getObjectTypeNameSpy).toBeCalledWith(date)
+    })
+
+    it('`true` を返す', () => {
+      expect(Checks.isDate(new Date('2020-10-10'))).toBe(true)
+    })
+
+    it('`false` を返す', () => {
+      expect(Checks.isDate('2020-10-10')).toBe(false)
+      expect(Checks.isDate(null)).toBe(false)
+    })
+  })
+
   describe('isNaN()', () => {
     it('`Checks.isNumber() を呼び出す`', () => {
       const isNumberSpy = jest.spyOn(Checks, 'isNumber')

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -34,6 +34,15 @@ export const Asserts = {
   },
 
   /**
+   * 値がDateかアサートする
+   * @param value
+   * @throw `value` がDateでない
+   */
+  isDate(value: unknown): asserts value is Date {
+    return
+  },
+
+  /**
    * 値が `NaN` かアサートする
    * @param value
    */

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -39,7 +39,7 @@ export const Asserts = {
    * @throw `value` がDateでない
    */
   isDate(value: unknown): asserts value is Date {
-    return
+    return assert(Checks.isDate(value), 'value is not a Date')
   },
 
   /**

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -43,6 +43,14 @@ export const Checks = {
   },
 
   /**
+   * 値がDateか否かを返す
+   * @param value
+   */
+  isDate(value: unknown): value is Date {
+    return true
+  },
+
+  /**
    * 値が `NaN` か否かを返す
    * @alias `Number.isNaN()`
    * @param value

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -47,7 +47,7 @@ export const Checks = {
    * @param value
    */
   isDate(value: unknown): value is Date {
-    return true
+    return getObjectTypeName(value) === '[object Date]'
   },
 
   /**


### PR DESCRIPTION
#13 

`isDate()` を実装します。

## 仕様

### `true`

- `isDate(new Date())`

### `false`

- `isDate('2020-10-10')`
- `isDate(null)`
