### PR TITLE
`isError()` を実装する

### DIFF
--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -157,7 +157,7 @@ describe('Asserts API', () => {
     })
 
     it('例外を投げる', () => {
-      expect(() => assertion(null)).toThrowError('value is not a Error')
+      expect(() => assertion(null)).toThrowError('value is not an Error')
       expect(checksAPISpy).toHaveReturnedWith(false)
     })
   })

--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -130,6 +130,38 @@ describe('Asserts API', () => {
     })
   })
 
+  describe('isError()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isError)
+      checksAPISpy = jest.spyOn(Checks, 'isError')
+    })
+
+    beforeEach(() => {
+      checksAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      checksAPISpy.mockRestore()
+    })
+
+    const error = new Error()
+
+    it('`Checks.isError()` を呼び出す', () => {
+      assertion(error)
+      expect(checksAPISpy).toHaveBeenCalledWith(error)
+    })
+
+    it('`void` を返す', () => {
+      expect(assertion(error)).toBeUndefined()
+      expect(checksAPISpy).toHaveReturnedWith(true)
+    })
+
+    it('例外を投げる', () => {
+      expect(() => assertion(null)).toThrowError('value is not a Error')
+      expect(checksAPISpy).toHaveReturnedWith(false)
+    })
+  })
+
   describe('isNaN()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isNaN)

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -96,6 +96,22 @@ describe('Checks API', () => {
     })
   })
 
+  describe('isError()', () => {
+    it('`getObjectTypeName()` を呼び出す', () => {
+      const error = new Error()
+      Checks.isError(error)
+      expect(getObjectTypeNameSpy).toBeCalledWith(error)
+    })
+
+    it('`true` を返す', () => {
+      expect(Checks.isError(new Error())).toBe(true)
+    })
+
+    it('`false` を返す', () => {
+      expect(Checks.isError(null)).toBe(false)
+    })
+  })
+
   describe('isNaN()', () => {
     it('`Checks.isNumber() を呼び出す`', () => {
       const isNumberSpy = jest.spyOn(Checks, 'isNumber')

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -48,7 +48,7 @@ export const Asserts = {
    * @throw `value` がErrorでない
    */
   isError(value: unknown): asserts value is Error {
-    return
+    return assert(Checks.isError(value), 'value is not an Error')
   },
 
   /**

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -43,6 +43,15 @@ export const Asserts = {
   },
 
   /**
+   * 値がErrorかアサートする
+   * @param value
+   * @throw `value` がErrorでない
+   */
+  isError(value: unknown): asserts value is Error {
+    return
+  },
+
+  /**
    * 値が `NaN` かアサートする
    * @param value
    */

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -55,7 +55,7 @@ export const Checks = {
    * @param value
    */
   isError(value: unknown): value is Error {
-    return true
+    return getObjectTypeName(value) === '[object Error]'
   },
 
   /**

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -51,6 +51,14 @@ export const Checks = {
   },
 
   /**
+   * 値がErrorか否かを返す
+   * @param value
+   */
+  isError(value: unknown): value is Error {
+    return true
+  },
+
+  /**
    * 値が `NaN` か否かを返す
    * @alias `Number.isNaN()`
    * @param value


### PR DESCRIPTION
#13 

`isError()` を実装します。

## 仕様

### `true`

- `isError(new Error())`

### `false`

- `isError(null)`
