### PR TITLE
`isFiniteNumber()` を実装する

### DIFF
--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -130,6 +130,38 @@ describe('Asserts API', () => {
     })
   })
 
+  describe('isFiniteNumber()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isFiniteNumber)
+      checksAPISpy = jest.spyOn(Checks, 'isFiniteNumber')
+    })
+
+    beforeEach(() => {
+      checksAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      checksAPISpy.mockRestore()
+    })
+
+    it('`Checks.isFiniteNumber()` を呼び出す', () => {
+      assertion(0)
+      expect(checksAPISpy).toHaveBeenCalledWith(0)
+    })
+
+    it('`void` を返す', () => {
+      expect(assertion(0)).toBeUndefined()
+      expect(checksAPISpy).toHaveReturnedWith(true)
+    })
+
+    it('例外を投げる', () => {
+      expect(() => assertion(Infinity)).toThrowError(
+        'value is not a finite number'
+      )
+      expect(checksAPISpy).toHaveReturnedWith(false)
+    })
+  })
+
   describe('isNaN()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isNaN)

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -107,7 +107,7 @@ describe('Checks API', () => {
     it('`Number.isFinite() を呼び出す`', () => {
       const isFiniteSpy = jest.spyOn(Number, 'isFinite')
       Checks.isFiniteNumber(0)
-      expect(isFinite).toBeCalledWith(0)
+      expect(isFiniteSpy).toBeCalledWith(0)
       isFiniteSpy.mockRestore()
     })
 

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -121,6 +121,7 @@ describe('Checks API', () => {
       expect(Checks.isFiniteNumber(Infinity)).toBe(false)
       expect(Checks.isFiniteNumber(-Infinity)).toBe(false)
       expect(Checks.isFiniteNumber(NaN)).toBe(false)
+      expect(Checks.isFiniteNumber('0')).toBe(false)
       expect(Checks.isFiniteNumber(null)).toBe(false)
     })
   })

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -96,6 +96,35 @@ describe('Checks API', () => {
     })
   })
 
+  describe('isFiniteNumber()', () => {
+    it('`Checks.isNumber() を呼び出す`', () => {
+      const isNumberSpy = jest.spyOn(Checks, 'isNumber')
+      Checks.isFiniteNumber(NaN)
+      expect(isNumberSpy).toBeCalledWith(NaN)
+      isNumberSpy.mockRestore()
+    })
+
+    it('`Number.isFinite() を呼び出す`', () => {
+      const isFiniteSpy = jest.spyOn(Number, 'isFinite')
+      Checks.isFiniteNumber(0)
+      expect(isFinite).toBeCalledWith(0)
+      isFiniteSpy.mockRestore()
+    })
+
+    it('`true` を返す', () => {
+      expect(Checks.isFiniteNumber(0)).toBe(true)
+      expect(Checks.isFiniteNumber(1)).toBe(true)
+      expect(Checks.isFiniteNumber(2e64)).toBe(true)
+    })
+
+    it('`false` を返す', () => {
+      expect(Checks.isFiniteNumber(Infinity)).toBe(false)
+      expect(Checks.isFiniteNumber(-Infinity)).toBe(false)
+      expect(Checks.isFiniteNumber(NaN)).toBe(false)
+      expect(Checks.isFiniteNumber(null)).toBe(false)
+    })
+  })
+
   describe('isNaN()', () => {
     it('`Checks.isNumber() を呼び出す`', () => {
       const isNumberSpy = jest.spyOn(Checks, 'isNumber')

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -43,6 +43,15 @@ export const Asserts = {
   },
 
   /**
+   * 値が有限数かアサートする
+   * @param value
+   * @throw `value` が有限数でない
+   */
+  isFiniteNumber(value: unknown): asserts value is number {
+    return
+  },
+
+  /**
    * 値が `NaN` かアサートする
    * @param value
    */

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -48,7 +48,7 @@ export const Asserts = {
    * @throw `value` が有限数でない
    */
   isFiniteNumber(value: unknown): asserts value is number {
-    return
+    return assert(Checks.isFiniteNumber(value), 'value is not a finite number')
   },
 
   /**

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -55,7 +55,7 @@ export const Checks = {
    * @param value
    */
   isFiniteNumber(value: unknown): value is number {
-    return true
+    return Checks.isNumber(value) && Number.isFinite(value)
   },
 
   /**

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -51,6 +51,14 @@ export const Checks = {
   },
 
   /**
+   * 値が有限数か否かを返す
+   * @param value
+   */
+  isFiniteNumber(value: unknown): value is number {
+    return true
+  },
+
+  /**
    * 値が `NaN` か否かを返す
    * @alias `Number.isNaN()`
    * @param value


### PR DESCRIPTION
#13 

`isFiniteNumber()` を実装します。

## 仕様

- `Checks.isNumber()` を用いる
- `Number.isFinite()` を用いる

### `true`

- `isFiniteNumber(0)`
- `isFiniteNumber(1)`
- `isFiniteNumber(2e64)`

### `false`

- `isFiniteNumber(Infinity)`
- `isFiniteNumber(-Infinity)`
- `isFiniteNumber(NaN)`
- `isFiniteNumber('0')`
- `isFiniteNumber(null)`

 テストケースはMDNを参照 → https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite
