### PR TITLE
`isInteger()` を実装する

### DIFF
--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -130,6 +130,36 @@ describe('Asserts API', () => {
     })
   })
 
+  describe('isInteger()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isInteger)
+      checksAPISpy = jest.spyOn(Checks, 'isInteger')
+    })
+
+    beforeEach(() => {
+      checksAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      checksAPISpy.mockRestore()
+    })
+
+    it('`Checks.isInteger()` を呼び出す', () => {
+      assertion(0)
+      expect(checksAPISpy).toHaveBeenCalledWith(0)
+    })
+
+    it('`void` を返す', () => {
+      expect(assertion(0)).toBeUndefined()
+      expect(checksAPISpy).toHaveReturnedWith(true)
+    })
+
+    it('例外を投げる', () => {
+      expect(() => assertion(null)).toThrowError('value is not a integer')
+      expect(checksAPISpy).toHaveReturnedWith(false)
+    })
+  })
+
   describe('isNaN()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isNaN)

--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -155,7 +155,7 @@ describe('Asserts API', () => {
     })
 
     it('例外を投げる', () => {
-      expect(() => assertion(null)).toThrowError('value is not a integer')
+      expect(() => assertion(null)).toThrowError('value is not an integer')
       expect(checksAPISpy).toHaveReturnedWith(false)
     })
   })

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -96,6 +96,39 @@ describe('Checks API', () => {
     })
   })
 
+  describe('isInteger()', () => {
+    it('`Checks.isNumber() を呼び出す`', () => {
+      const isNumberSpy = jest.spyOn(Checks, 'isNumber')
+      Checks.isInteger(0)
+      expect(isNumberSpy).toBeCalledWith(0)
+      isNumberSpy.mockRestore()
+    })
+
+    it('`Number.isInteger() を呼び出す`', () => {
+      const isIntegerSpy = jest.spyOn(Number, 'isInteger')
+      Checks.isInteger(NaN)
+      expect(isIntegerSpy).toBeCalledWith(NaN)
+      isIntegerSpy.mockRestore()
+    })
+
+    it('`true` を返す', () => {
+      expect(Checks.isInteger(0)).toBe(true)
+      expect(Checks.isInteger(1)).toBe(true)
+      expect(Checks.isInteger(-100000)).toBe(true)
+      expect(Checks.isInteger(99999999999999999999999)).toBe(true)
+    })
+
+    it('`false` を返す', () => {
+      expect(Checks.isInteger(0.1)).toBe(false)
+      expect(Checks.isInteger(Math.PI)).toBe(false)
+      expect(Checks.isInteger(NaN)).toBe(false)
+      expect(Checks.isInteger(Infinity)).toBe(false)
+      expect(Checks.isInteger(-Infinity)).toBe(false)
+      expect(Checks.isInteger('10')).toBe(false)
+      expect(Checks.isInteger(null)).toBe(false)
+    })
+  })
+
   describe('isNaN()', () => {
     it('`Checks.isNumber() を呼び出す`', () => {
       const isNumberSpy = jest.spyOn(Checks, 'isNumber')

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -43,6 +43,15 @@ export const Asserts = {
   },
 
   /**
+   * 値が整数かアサートする
+   * @param value
+   * @throw `value` が整数でない
+   */
+  isInteger(value: unknown): asserts value is number {
+    return
+  },
+
+  /**
    * 値が `NaN` かアサートする
    * @param value
    */

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -48,7 +48,7 @@ export const Asserts = {
    * @throw `value` が整数でない
    */
   isInteger(value: unknown): asserts value is number {
-    return
+    return assert(Checks.isInteger(value), 'value is not an integer')
   },
 
   /**

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -55,7 +55,7 @@ export const Checks = {
    * @param value
    */
   isInteger(value: unknown): value is number {
-    return true
+    return Checks.isNumber(value) && Number.isInteger(value)
   },
 
   /**

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -51,6 +51,14 @@ export const Checks = {
   },
 
   /**
+   * 値が整数か否かを返す
+   * @param value
+   */
+  isInteger(value: unknown): value is number {
+    return true
+  },
+
+  /**
    * 値が `NaN` か否かを返す
    * @alias `Number.isNaN()`
    * @param value

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -52,6 +52,7 @@ export const Checks = {
 
   /**
    * 値が整数か否かを返す
+   * @alias `Number.isInteger()`
    * @param value
    */
   isInteger(value: unknown): value is number {


### PR DESCRIPTION
#13 

`isInteger()` を実装します。

## 仕様

- `Checks.isNumber()` を用いる
- `Number.isInteger)` を用いる

### `true`

- `isInteger(0)`
- `isInteger(1)`
- `isInteger(-100000)`
- `isInteger(99999999999999999999999)`

### `false`

- `isInteger(0.1)`
- `isInteger(Math.PI)`
- `isInteger(NaN)`
- `isInteger(Infinity)`
- `isInteger(-Infinity)`
- `isInteger('0')`
- `isInteger(null)`

 テストケースはMDNを参照 → https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger
