### PR TITLE
feat: remove generics from isPromise/isPromiseLike

### DIFF
--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -102,7 +102,7 @@ export const Asserts = {
    * @param value
    * @throw `value` がPromiseでない
    */
-  isPromise<T>(value: unknown): asserts value is Promise<T> {
+  isPromise(value: unknown): asserts value is Promise<unknown> {
     assert(Checks.isPromise(value), 'value is not a Promise')
   },
 
@@ -111,7 +111,7 @@ export const Asserts = {
    * @param value
    * @throw `value` がPromiseLikeでない
    */
-  isPromiseLike<T>(value: unknown): asserts value is PromiseLike<T> {
+  isPromiseLike(value: unknown): asserts value is PromiseLike<unknown> {
     assert(Checks.isPromiseLike(value), 'value is not a PromiseLike')
   },
 

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -107,7 +107,7 @@ export const Checks = {
    * 値がビルトインの `Promise` オブジェクトか否かを返す
    * @param value
    */
-  isPromise<T>(value: unknown): value is Promise<T> {
+  isPromise(value: unknown): value is Promise<unknown> {
     return getObjectTypeName(value) === '[object Promise]'
   },
 
@@ -115,7 +115,7 @@ export const Checks = {
    * 値が `PromiseLike` なオブジェクトか否かを返す
    * @param value
    */
-  isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
+  isPromiseLike(value: unknown): value is PromiseLike<unknown> {
     if (Checks.isPromise(value)) {
       return true
     }


### PR DESCRIPTION
型安全のために型チェックからジェネリクスを外す対応。

reference: https://github.com/maboroshi-inc/type-assertions/pull/36#discussion_r355360731
related: https://github.com/maboroshi-inc/type-assertions/pull/43