### PR TITLE
`isObject()` を実装する

### DIFF
--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -343,6 +343,37 @@ describe('Asserts API', () => {
     })
   })
 
+  describe('isObject()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isObject)
+      checksAPISpy = jest.spyOn(Checks, 'isObject')
+    })
+
+    beforeEach(() => {
+      checksAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      checksAPISpy.mockRestore()
+    })
+
+    const object = { key: 'VALUE' }
+
+    it('`Checks.isObject()` を呼び出す', () => {
+      assertion(object)
+      expect(checksAPISpy).toHaveBeenCalledWith(object)
+    })
+
+    it('`void` を返す', () => {
+      expect(assertion(object)).toBeUndefined()
+      expect(checksAPISpy).toHaveReturnedWith(true)
+    })
+
+    it('例外を投げる', () => {
+      expect(() => assertion(null)).toThrowError('value is not an object')
+    })
+  })
+
   describe('isPromise()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isPromise)

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -262,25 +262,38 @@ describe('Checks API', () => {
       key = 'VALUE'
     }
 
-    it('`getObjectTypeName()` を呼び出す', () => {
+    it('`Checks.isNull() を呼び出す`', () => {
+      const isNullSpy = jest.spyOn(Checks, 'isNull')
       Checks.isObject(object)
-      expect(getObjectTypeNameSpy).toBeCalledWith(object)
+      expect(isNullSpy).toBeCalledWith(object)
+      isNullSpy.mockRestore()
     })
 
-    it('`true` を返す', () => {
-      expect(Checks.isObject(object)).toBe(true)
-      expect(Checks.isObject({})).toBe(true)
-      expect(Checks.isObject(Object.create(object))).toBe(true)
-      expect(Checks.isObject(Object.create(null))).toBe(true)
-      expect(Checks.isObject(new DummyClassForIsObjectTesting())).toBe(true)
+    it.each([
+      object,
+      [],
+      new Boolean(0), // eslint-disable-line no-new-wrappers
+      new Number(123), // eslint-disable-line no-new-wrappers
+      new String('string'), // eslint-disable-line no-new-wrappers
+      new Map(),
+      new Set(),
+      new DummyClassForIsObjectTesting()
+    ])('`true` を返す', value => {
+      expect(Checks.isObject(value)).toBe(true)
     })
 
-    it('`false` を返す', () => {
-      expect(Checks.isObject(null)).toBe(false)
-      expect(Checks.isObject([])).toBe(false)
-      expect(Checks.isObject(() => undefined)).toBe(false)
-      expect(Checks.isObject(new Map())).toBe(false)
-      expect(Checks.isObject(new Set())).toBe(false)
+    it.each([
+      undefined,
+      null,
+      123,
+      NaN,
+      'string',
+      true,
+      false,
+      Symbol('symbol'),
+      (): void => undefined
+    ])('`false` を返す', value => {
+      expect(Checks.isObject(value)).toBe(false)
     })
   })
 

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -256,6 +256,34 @@ describe('Checks API', () => {
     })
   })
 
+  describe('isObject()', () => {
+    const object = { key: 'VALUE' }
+    class DummyClassForIsObjectTesting {
+      key = 'VALUE'
+    }
+
+    it('`getObjectTypeName()` を呼び出す', () => {
+      Checks.isObject(object)
+      expect(getObjectTypeNameSpy).toBeCalledWith(object)
+    })
+
+    it('`true` を返す', () => {
+      expect(Checks.isObject(object)).toBe(true)
+      expect(Checks.isObject({})).toBe(true)
+      expect(Checks.isObject(Object.create(object))).toBe(true)
+      expect(Checks.isObject(Object.create(null))).toBe(true)
+      expect(Checks.isObject(new DummyClassForIsObjectTesting())).toBe(true)
+    })
+
+    it('`false` を返す', () => {
+      expect(Checks.isObject(null)).toBe(false)
+      expect(Checks.isObject([])).toBe(false)
+      expect(Checks.isObject(() => undefined)).toBe(false)
+      expect(Checks.isObject(new Map())).toBe(false)
+      expect(Checks.isObject(new Set())).toBe(false)
+    })
+  })
+
   describe('isPromise()', () => {
     it('`getObjectTypeName()` を呼び出す', () => {
       Checks.isPromise(Promise.resolve(123))

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -112,7 +112,7 @@ export const Asserts = {
    * @throw `value` がobjectでない
    */
   isObject(value: unknown): asserts value is object {
-    return
+    return assert(Checks.isObject(value), 'value is not an object')
   },
 
   /**

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -107,6 +107,15 @@ export const Asserts = {
   },
 
   /**
+   * 値がビルトインのobjectかアサートする
+   * @param value
+   * @throw `value` がobjectでない
+   */
+  isObject(value: unknown): asserts value is object {
+    return
+  },
+
+  /**
    * 値がビルトインの `Promise` オブジェクトかアサートする
    * @param value
    * @throw `value` がPromiseでない

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -116,7 +116,7 @@ export const Checks = {
    * @param value
    */
   isObject(value: unknown): value is object {
-    return true
+    return getObjectTypeName(value) === '[object Object]'
   },
 
   /**

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -117,7 +117,7 @@ export const Checks = {
    * @param value
    */
   isObject(value: unknown): value is object {
-    return getObjectTypeName(value) === '[object Object]'
+    return typeof value === 'object' && !Checks.isNull(value)
   },
 
   /**

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -113,6 +113,7 @@ export const Checks = {
 
   /**
    * 値がobjectか否かを返す
+   * @description `null` 及びプリミティブ値以外をすべて `true` とする
    * @param value
    */
   isObject(value: unknown): value is object {

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -112,6 +112,14 @@ export const Checks = {
   },
 
   /**
+   * 値がobjectか否かを返す
+   * @param value
+   */
+  isObject(value: unknown): value is object {
+    return true
+  },
+
+  /**
    * 値がビルトインの `Promise` オブジェクトか否かを返す
    * @param value
    */


### PR DESCRIPTION
#13 

## true
- `isObject({ key: 'VALUE' })`
- `isObject([])`
- `isObject(new Hoge())`

## false
- `isObject(undefined)`
- `isObject(null)`
- `isObject(123)`
- `isObject('string')`
- `isObject(true)`
- `isObject(Symbol())`
- `isObject(() => undefined)`
