### PR TITLE
`isRegExp()` を実装する

### DIFF
--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -445,6 +445,37 @@ describe('Asserts API', () => {
     })
   })
 
+  describe('isRegExp', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isRegExp)
+      checksAPISpy = jest.spyOn(Checks, 'isRegExp')
+    })
+
+    beforeEach(() => {
+      checksAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      checksAPISpy.mockRestore()
+    })
+
+    it('`Checks.isRegExp()` を呼び出す', () => {
+      const expected = /^.+$/
+
+      assertion(expected)
+      expect(checksAPISpy).toHaveBeenCalledWith(expected)
+    })
+
+    it('`void` を返す', () => {
+      expect(assertion(/^.+$/)).toBeUndefined()
+      expect(checksAPISpy).toHaveReturnedWith(true)
+    })
+
+    it('例外を投げる', () => {
+      expect(() => assertion(null)).toThrowError('value is not a RegExp')
+    })
+  })
+
   describe('isMap()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isMap)

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -323,6 +323,25 @@ describe('Checks API', () => {
     })
   })
 
+  describe('isRegExp()', () => {
+    it('`getObjectTypeName()` を呼び出す', () => {
+      const expected = /^.+$/
+
+      Checks.isRegExp(expected)
+      expect(getObjectTypeNameSpy).toBeCalledWith(expected)
+    })
+
+    it('`true` を返す', () => {
+      expect(Checks.isRegExp(/^.+$/)).toBe(true)
+      expect(Checks.isRegExp(new RegExp('^.+$'))).toBe(true)
+    })
+
+    it('`false` を返す', () => {
+      expect(Checks.isRegExp(`/^.+$/`)).toBe(false)
+      expect(Checks.isRegExp(null)).toBe(false)
+    })
+  })
+
   describe('isMap()', () => {
     it('`getObjectTypeName()` を呼び出す', () => {
       const expected = new Map()

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -125,6 +125,15 @@ export const Asserts = {
   },
 
   /**
+   * 値が正規表現オブジェクトかアサートする
+   * @param value
+   * @throw `value` が正規表現オブジェクトでない
+   */
+  isRegExp(value: unknown): asserts value is RegExp {
+    return assert(Checks.isRegExp(value), 'value is not a RegExp')
+  },
+
+  /**
    * 値が `Map` かアサートする
    * @param value
    * @throw `value` が `Map` でない

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -136,6 +136,14 @@ export const Checks = {
   },
 
   /**
+   * 値が正規表現オブジェクトか否かを返す
+   * @param value
+   */
+  isRegExp(value: unknown): value is RegExp {
+    return true
+  },
+
+  /**
    * 値が `Map` か否かを返す
    * @param value
    */

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -140,7 +140,7 @@ export const Checks = {
    * @param value
    */
   isRegExp(value: unknown): value is RegExp {
-    return true
+    return getObjectTypeName(value) === '[object RegExp]'
   },
 
   /**


### PR DESCRIPTION
#13 

## true
- `isRegExp(/^.+$/)`
- `isRegExp(new RegExp('^.+$'))`

## false
- `isRegExp('/^.+$/')`
- `isRegExp(null)`
