### PR TITLE
`isSafeInteger()` を実装する

### DIFF
--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -542,6 +542,36 @@ describe('Asserts API', () => {
     })
   })
 
+  describe('isSafeInteger()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isSafeInteger)
+      checksAPISpy = jest.spyOn(Checks, 'isSafeInteger')
+    })
+
+    beforeEach(() => {
+      checksAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      checksAPISpy.mockRestore()
+    })
+
+    it('`Checks.isSafeInteger()` を呼び出す', () => {
+      assertion(0)
+      expect(checksAPISpy).toHaveBeenCalledWith(0)
+    })
+
+    it('`void` を返す', () => {
+      expect(assertion(0)).toBeUndefined()
+      expect(checksAPISpy).toHaveReturnedWith(true)
+    })
+
+    it('例外を投げる', () => {
+      expect(() => assertion(null)).toThrowError('value is not a safe integer')
+      expect(checksAPISpy).toHaveReturnedWith(false)
+    })
+  })
+
   describe('isMap()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isMap)

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -417,6 +417,7 @@ describe('Checks API', () => {
 
     it('`true` を返す', () => {
       expect(Checks.isSafeInteger(123)).toBe(true)
+      expect(Checks.isSafeInteger(Math.pow(2, 53) - 1)).toBe(true)
     })
 
     it('`false` を返す', () => {

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -400,6 +400,36 @@ describe('Checks API', () => {
     })
   })
 
+  describe('isSafeInteger', () => {
+    it('`Checks.isNumber() を呼び出す`', () => {
+      const isNumberSpy = jest.spyOn(Checks, 'isNumber')
+      Checks.isSafeInteger(123)
+      expect(isNumberSpy).toBeCalledWith(123)
+      isNumberSpy.mockRestore()
+    })
+
+    it('`Number.isSafeInteger() を呼び出す`', () => {
+      const isSafeIntegerSpy = jest.spyOn(Number, 'isSafeInteger')
+      Checks.isSafeInteger(123)
+      expect(isSafeIntegerSpy).toBeCalledWith(123)
+      isSafeIntegerSpy.mockRestore()
+    })
+
+    it('`true` を返す', () => {
+      expect(Checks.isSafeInteger(123)).toBe(true)
+    })
+
+    it('`false` を返す', () => {
+      expect(Checks.isSafeInteger(Math.pow(2, 53))).toBe(false)
+      expect(Checks.isSafeInteger(Math.PI)).toBe(false)
+      expect(Checks.isSafeInteger(NaN)).toBe(false)
+      expect(Checks.isSafeInteger(Infinity)).toBe(false)
+      expect(Checks.isSafeInteger(-Infinity)).toBe(false)
+      expect(Checks.isSafeInteger('string')).toBe(false)
+      expect(Checks.isSafeInteger(null)).toBe(false)
+    })
+  })
+
   describe('isMap()', () => {
     it('`getObjectTypeName()` を呼び出す', () => {
       const expected = new Map()

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -152,6 +152,15 @@ export const Asserts = {
   },
 
   /**
+   * 値が safe integer かアサートする
+   * @param value
+   * @throw `value` が safe integer でない
+   */
+  isSafeInteger(value: unknown): asserts value is number {
+    return assert(Checks.isSafeInteger(value), 'value is not a safe integer')
+  },
+
+  /**
    * 値が `Map` かアサートする
    * @param value
    * @throw `value` が `Map` でない

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -162,6 +162,15 @@ export const Checks = {
   },
 
   /**
+   * 値が safe integer か否かを返す
+   * @alias `Number.isSafeInteger()`
+   * @param value
+   */
+  isSafeInteger(value: unknown): value is number {
+    return Checks.isNumber(value) && Number.isSafeInteger(value)
+  },
+
+  /**
    * 値が `Map` か否かを返す
    * @param value
    */


### PR DESCRIPTION
#13 

- `Checks.isNumber()` を用いる
- `Number.isSafeInteger)` を用いる

### `true`

- `123`
- `Math.pow(2, 53) - 1`

### `false`

- `Math.pow(2, 53)`
- `Math.PI`
- `NaN`
- `Infinity`
- `-Infinity`
- `'string'`
- `null`

 テストケースはMDNを参照 → https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger
