### PR TITLE
`isPlainObject()` を実装する

### DIFF
--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -409,10 +409,10 @@ describe('Asserts API', () => {
     })
   })
 
-  describe('isPlaneObject()', () => {
+  describe('isPlainObject()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isPlaneObject)
-      checksAPISpy = jest.spyOn(Checks, 'isPlaneObject')
+      checksAPISpy = jest.spyOn(Checks, 'isPlainObject')
     })
 
     beforeEach(() => {
@@ -425,7 +425,7 @@ describe('Asserts API', () => {
 
     const object = { key: 'VALUE' }
 
-    it('`Checks.isPlaneObject()` を呼び出す', () => {
+    it('`Checks.isPlainObject()` を呼び出す', () => {
       assertion(object)
       expect(checksAPISpy).toHaveBeenCalledWith(object)
     })

--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -409,6 +409,37 @@ describe('Asserts API', () => {
     })
   })
 
+  describe('isPlaneObject()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isPlaneObject)
+      checksAPISpy = jest.spyOn(Checks, 'isPlaneObject')
+    })
+
+    beforeEach(() => {
+      checksAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      checksAPISpy.mockRestore()
+    })
+
+    const object = { key: 'VALUE' }
+
+    it('`Checks.isPlaneObject()` を呼び出す', () => {
+      assertion(object)
+      expect(checksAPISpy).toHaveBeenCalledWith(object)
+    })
+
+    it('`void` を返す', () => {
+      expect(assertion(object)).toBeUndefined()
+      expect(checksAPISpy).toHaveReturnedWith(true)
+    })
+
+    it('例外を投げる', () => {
+      expect(() => assertion(null)).toThrowError('value is not a plane object')
+    })
+  })
+
   describe('isPromise()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isPromise)

--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -411,7 +411,7 @@ describe('Asserts API', () => {
 
   describe('isPlainObject()', () => {
     beforeAll(() => {
-      assertion = createAssertion(Asserts.isPlaneObject)
+      assertion = createAssertion(Asserts.isPlainObject)
       checksAPISpy = jest.spyOn(Checks, 'isPlainObject')
     })
 

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -314,20 +314,20 @@ describe('Checks API', () => {
     })
   })
 
-  describe('isPlaneObject()', () => {
+  describe('isPlainObject()', () => {
     const object = { key: 'VALUE' }
     class DummyClassForIsPlaneObjectTesting {
       key = 'VALUE'
     }
 
     it('`getObjectTypeName()` を呼び出す', () => {
-      Checks.isPlaneObject(object)
+      Checks.isPlainObject(object)
       expect(getObjectTypeNameSpy).toBeCalledWith(object)
     })
 
     it('`Checks.isObject() を呼び出す`', () => {
       const isObjectSpy = jest.spyOn(Checks, 'isObject')
-      Checks.isPlaneObject(object)
+      Checks.isPlainObject(object)
       expect(isObjectSpy).toBeCalledWith(object)
       isObjectSpy.mockRestore()
     })
@@ -337,7 +337,7 @@ describe('Checks API', () => {
       new Object(), // eslint-disable-line no-new-object
       Object.create(object)
     ])('`true` を返す', value => {
-      expect(Checks.isPlaneObject(value)).toBe(true)
+      expect(Checks.isPlainObject(value)).toBe(true)
     })
 
     it.each([
@@ -359,7 +359,7 @@ describe('Checks API', () => {
       new Set(),
       new DummyClassForIsPlaneObjectTesting()
     ])('`false` を返す', value => {
-      expect(Checks.isPlaneObject(value)).toBe(false)
+      expect(Checks.isPlainObject(value)).toBe(false)
     })
   })
 

--- a/__tests__/checks.spec.ts
+++ b/__tests__/checks.spec.ts
@@ -314,6 +314,55 @@ describe('Checks API', () => {
     })
   })
 
+  describe('isPlaneObject()', () => {
+    const object = { key: 'VALUE' }
+    class DummyClassForIsPlaneObjectTesting {
+      key = 'VALUE'
+    }
+
+    it('`getObjectTypeName()` を呼び出す', () => {
+      Checks.isPlaneObject(object)
+      expect(getObjectTypeNameSpy).toBeCalledWith(object)
+    })
+
+    it('`Checks.isObject() を呼び出す`', () => {
+      const isObjectSpy = jest.spyOn(Checks, 'isObject')
+      Checks.isPlaneObject(object)
+      expect(isObjectSpy).toBeCalledWith(object)
+      isObjectSpy.mockRestore()
+    })
+
+    it.each([
+      object,
+      new Object(), // eslint-disable-line no-new-object
+      Object.create(object)
+    ])('`true` を返す', value => {
+      expect(Checks.isPlaneObject(value)).toBe(true)
+    })
+
+    it.each([
+      undefined,
+      null,
+      123,
+      NaN,
+      'string',
+      true,
+      false,
+      Symbol('symbol'),
+      (): void => undefined,
+      [],
+      Object.create(null),
+      new Boolean(0), // eslint-disable-line no-new-wrappers
+      new Number(123), // eslint-disable-line no-new-wrappers
+      new String('string'), // eslint-disable-line no-new-wrappers
+      new Map(),
+      new Set(),
+      new DummyClassForIsPlaneObjectTesting()
+    ])('`false` を返す', value => {
+      expect(Checks.isPlaneObject(value)).toBe(false)
+    })
+  })
+
   describe('isPromise()', () => {
     it('`getObjectTypeName()` を呼び出す', () => {
       Checks.isPromise(Promise.resolve(123))

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -125,6 +125,15 @@ export const Asserts = {
   },
 
   /**
+   * 値がObjectオブジェクトかアサートする
+   * @param value
+   * @throw `value` がObjectオブジェクトでない
+   */
+  isPlaneObject(value: unknown): asserts value is object {
+    return assert(Checks.isPlaneObject(value), 'value is not a plane object')
+  },
+
+  /**
    * 値がビルトインの `Promise` オブジェクトかアサートする
    * @param value
    * @throw `value` がPromiseでない

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -130,7 +130,7 @@ export const Asserts = {
    * @throw `value` がObjectオブジェクトでない
    */
   isPlaneObject(value: unknown): asserts value is object {
-    return assert(Checks.isPlaneObject(value), 'value is not a plane object')
+    return assert(Checks.isPlainObject(value), 'value is not a plane object')
   },
 
   /**

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -129,7 +129,7 @@ export const Asserts = {
    * @param value
    * @throw `value` がObjectオブジェクトでない
    */
-  isPlaneObject(value: unknown): asserts value is object {
+  isPlainObject(value: unknown): asserts value is object {
     return assert(Checks.isPlainObject(value), 'value is not a plane object')
   },
 

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -135,7 +135,11 @@ export const Checks = {
    * @param value
    */
   isPlaneObject(value: unknown): value is object {
-    return true
+    return (
+      Checks.isObject(value) && // パフォーマンスアップのために最初にプリミティブ値を弾く
+      getObjectTypeName(value) === '[object Object]' &&
+      value.constructor === Object.prototype.constructor // constructor を比較してカスタムクラスを弾く
+    )
   },
 
   /**

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -134,7 +134,7 @@ export const Checks = {
    * @description `Object` のみを `true` とする
    * @param value
    */
-  isPlaneObject(value: unknown): value is object {
+  isPlainObject(value: unknown): value is object {
     return (
       Checks.isObject(value) && // パフォーマンスアップのために最初にプリミティブ値を弾く
       getObjectTypeName(value) === '[object Object]' &&

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -130,6 +130,15 @@ export const Checks = {
   },
 
   /**
+   * 値がobjectか否かを返す
+   * @description `Object` のみを `true` とする
+   * @param value
+   */
+  isPlaneObject(value: unknown): value is object {
+    return true
+  },
+
+  /**
    * 値がビルトインの `Promise` オブジェクトか否かを返す
    * @param value
    */

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -130,7 +130,7 @@ export const Checks = {
   },
 
   /**
-   * 値がobjectか否かを返す
+   * 値がObjectオブジェクトか否かを返す
    * @description `Object` のみを `true` とする
    * @param value
    */


### PR DESCRIPTION
#55 の実装を残しつつ機能名とブランチをリネームして改めてプルリクするものです。

#13 

## true
- `{ key: 'VALUE' }`
- `new Object()`
- `Object.create(aDefinedObject)`

## false
- `undefined`
- `null`
- `123`
- `'string'`
- `true`
- `Symbol()`
- `Object.create(null)`
- `new Hoge()`
