### PR TITLE
fix: type of `value` of `Asserts.isNumber()`

### DIFF
--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -101,7 +101,7 @@ export const Asserts = {
    * @param value
    * @throw `value` が数値でない
    */
-  isNumber(value: any): asserts value is number {
+  isNumber(value: unknown): asserts value is number {
     return assert(Checks.isNumber(value), 'value is not a number')
   },
 


### PR DESCRIPTION
#7 

`Asserts.isNumber()` の `value` の型を `any` から `unknown` に変更した。
