### PR TITLE
chore: sort methods

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["@maboroshi/eslint-config"]
+  "extends": ["@maboroshi/eslint-config"],
+  "rules": {
+    "sort-keys": ["error", "asc", { "natural": true }]
+  }
 }

--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -130,41 +130,6 @@ describe('Asserts API', () => {
     })
   })
 
-  describe('isValidDate()', () => {
-    beforeAll(() => {
-      assertion = createAssertion(Asserts.isValidDate)
-      guardsAPISpy = jest.spyOn(Guards, 'isValidDate')
-    })
-
-    beforeEach(() => {
-      guardsAPISpy.mockClear()
-    })
-
-    afterAll(() => {
-      guardsAPISpy.mockRestore()
-    })
-
-    it('`Guards.isValidDate()` を呼び出す', () => {
-      const date = new Date('2020-10-10')
-
-      assertion(date)
-      expect(guardsAPISpy).toHaveBeenCalledWith(date)
-    })
-
-    it.each([new Date(), new Date('2020-10-10')])(
-      '%o => `void` を返す',
-      value => {
-        expect(() => assertion(value)).not.toThrowError()
-        expect(guardsAPISpy).toHaveReturnedWith(true)
-      }
-    )
-
-    it.each([new Date('20201010'), null])('%o => 例外を投げる', value => {
-      expect(() => assertion(value)).toThrowError('value is not a valid Date')
-      expect(guardsAPISpy).toHaveReturnedWith(false)
-    })
-  })
-
   describe('isError()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isError)
@@ -229,6 +194,85 @@ describe('Asserts API', () => {
     })
   })
 
+  describe('isFunction()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isFunction)
+      guardsAPISpy = jest.spyOn(Guards, 'isFunction')
+    })
+
+    beforeEach(() => {
+      guardsAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      guardsAPISpy.mockRestore()
+    })
+
+    it('`Guards.isFunction()` を呼び出す', () => {
+      const fn = (): number => 42
+
+      assertion(fn)
+      expect(guardsAPISpy).toHaveBeenCalledWith(fn)
+    })
+
+    it.each([
+      (): number => 42,
+      // eslint-disable-next-line no-new-func
+      new Function('return 42')
+    ])('チェックをパスする', value => {
+      expect(assertion(value)).toBeUndefined()
+      expect(guardsAPISpy).toHaveReturnedWith(true)
+    })
+
+    it.each([
+      function*(): Generator<number, void> {
+        yield 42
+      },
+      null
+    ])('例外を投げる', value => {
+      expect(() => assertion(value)).toThrowError('value is not a function')
+    })
+  })
+
+  describe('isGeneratorFunction()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isGeneratorFunction)
+      guardsAPISpy = jest.spyOn(Guards, 'isGeneratorFunction')
+    })
+
+    beforeEach(() => {
+      guardsAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      guardsAPISpy.mockRestore()
+    })
+
+    it('`Guards.isGeneratorFunction()` を呼び出す', () => {
+      function* fn(): Generator<number> {
+        yield 42
+      }
+
+      assertion(fn)
+      expect(guardsAPISpy).toHaveBeenCalledWith(fn)
+    })
+
+    it.each([
+      function* fn(): Generator<number> {
+        yield 42
+      }
+    ])('チェックをパスする', value => {
+      expect(assertion(value)).toBeUndefined()
+      expect(guardsAPISpy).toHaveReturnedWith(true)
+    })
+
+    it.each([(): number => 42, null])('例外を投げる', value => {
+      expect(() => assertion(value)).toThrowError(
+        'value is not a generator function'
+      )
+    })
+  })
+
   describe('isInteger()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isInteger)
@@ -255,6 +299,43 @@ describe('Asserts API', () => {
 
     it('例外を投げる', () => {
       expect(() => assertion(null)).toThrowError('value is not an integer')
+      expect(guardsAPISpy).toHaveReturnedWith(false)
+    })
+  })
+
+  describe('isMap()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isMap)
+      guardsAPISpy = jest.spyOn(Guards, 'isMap')
+    })
+
+    beforeEach(() => {
+      guardsAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      guardsAPISpy.mockRestore()
+    })
+
+    it('`Guards.isMap()` を呼び出す', () => {
+      const expected = new Map()
+
+      assertion(expected)
+      expect(guardsAPISpy).toHaveBeenCalledWith(expected)
+    })
+
+    it.each([new Map()])('チェックをパスする', map => {
+      expect(() => assertion(map)).not.toThrowError()
+      expect(guardsAPISpy).toHaveReturnedWith(true)
+    })
+
+    it.each([
+      Object.create(null), // dictionary
+      new Set(),
+      new WeakMap(),
+      null
+    ])('例外を投げる', value => {
+      expect(() => assertion(value)).toThrowError('value is not a Map')
       expect(guardsAPISpy).toHaveReturnedWith(false)
     })
   })
@@ -349,35 +430,6 @@ describe('Asserts API', () => {
     })
   })
 
-  describe('isStrictNumber()', () => {
-    beforeAll(() => {
-      assertion = createAssertion(Asserts.isStrictNumber)
-      guardsAPISpy = jest.spyOn(Guards, 'isStrictNumber')
-    })
-
-    beforeEach(() => {
-      guardsAPISpy.mockClear()
-    })
-
-    afterAll(() => {
-      guardsAPISpy.mockRestore()
-    })
-
-    it('`Guards.isStrictNumber()` を呼び出す', () => {
-      assertion(123)
-      expect(guardsAPISpy).toHaveBeenCalledWith(123)
-    })
-
-    it('`void` を返す', () => {
-      expect(assertion(123)).toBeUndefined()
-      expect(guardsAPISpy).toHaveReturnedWith(true)
-    })
-
-    it('例外を投げる', () => {
-      expect(() => assertion(NaN)).toThrowError('value is not a strict number')
-    })
-  })
-
   describe('isObject()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isObject)
@@ -437,85 +489,6 @@ describe('Asserts API', () => {
 
     it('例外を投げる', () => {
       expect(() => assertion(null)).toThrowError('value is not a plane object')
-    })
-  })
-
-  describe('isFunction()', () => {
-    beforeAll(() => {
-      assertion = createAssertion(Asserts.isFunction)
-      guardsAPISpy = jest.spyOn(Guards, 'isFunction')
-    })
-
-    beforeEach(() => {
-      guardsAPISpy.mockClear()
-    })
-
-    afterAll(() => {
-      guardsAPISpy.mockRestore()
-    })
-
-    it('`Guards.isFunction()` を呼び出す', () => {
-      const fn = (): number => 42
-
-      assertion(fn)
-      expect(guardsAPISpy).toHaveBeenCalledWith(fn)
-    })
-
-    it.each([
-      (): number => 42,
-      // eslint-disable-next-line no-new-func
-      new Function('return 42')
-    ])('チェックをパスする', value => {
-      expect(assertion(value)).toBeUndefined()
-      expect(guardsAPISpy).toHaveReturnedWith(true)
-    })
-
-    it.each([
-      function*(): Generator<number, void> {
-        yield 42
-      },
-      null
-    ])('例外を投げる', value => {
-      expect(() => assertion(value)).toThrowError('value is not a function')
-    })
-  })
-
-  describe('isGeneratorFunction()', () => {
-    beforeAll(() => {
-      assertion = createAssertion(Asserts.isGeneratorFunction)
-      guardsAPISpy = jest.spyOn(Guards, 'isGeneratorFunction')
-    })
-
-    beforeEach(() => {
-      guardsAPISpy.mockClear()
-    })
-
-    afterAll(() => {
-      guardsAPISpy.mockRestore()
-    })
-
-    it('`Guards.isGeneratorFunction()` を呼び出す', () => {
-      function* fn(): Generator<number> {
-        yield 42
-      }
-
-      assertion(fn)
-      expect(guardsAPISpy).toHaveBeenCalledWith(fn)
-    })
-
-    it.each([
-      function* fn(): Generator<number> {
-        yield 42
-      }
-    ])('チェックをパスする', value => {
-      expect(assertion(value)).toBeUndefined()
-      expect(guardsAPISpy).toHaveReturnedWith(true)
-    })
-
-    it.each([(): number => 42, null])('例外を投げる', value => {
-      expect(() => assertion(value)).toThrowError(
-        'value is not a generator function'
-      )
     })
   })
 
@@ -682,6 +655,67 @@ describe('Asserts API', () => {
     })
   })
 
+  describe('isSet()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isSet)
+      guardsAPISpy = jest.spyOn(Guards, 'isSet')
+    })
+
+    beforeEach(() => {
+      guardsAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      guardsAPISpy.mockRestore()
+    })
+
+    it('`Guards.isSet()` を呼び出す', () => {
+      const expected = new Set()
+
+      assertion(expected)
+      expect(guardsAPISpy).toHaveBeenCalledWith(expected)
+    })
+
+    it.each([new Set()])('チェックをパスする', value => {
+      expect(() => assertion(value)).not.toThrowError()
+      expect(guardsAPISpy).toHaveReturnedWith(true)
+    })
+
+    it.each([[], new WeakSet(), null])('例外を投げる', value => {
+      expect(() => assertion(value)).toThrowError('value is not a Set')
+      expect(guardsAPISpy).toHaveReturnedWith(false)
+    })
+  })
+
+  describe('isStrictNumber()', () => {
+    beforeAll(() => {
+      assertion = createAssertion(Asserts.isStrictNumber)
+      guardsAPISpy = jest.spyOn(Guards, 'isStrictNumber')
+    })
+
+    beforeEach(() => {
+      guardsAPISpy.mockClear()
+    })
+
+    afterAll(() => {
+      guardsAPISpy.mockRestore()
+    })
+
+    it('`Guards.isStrictNumber()` を呼び出す', () => {
+      assertion(123)
+      expect(guardsAPISpy).toHaveBeenCalledWith(123)
+    })
+
+    it('`void` を返す', () => {
+      expect(assertion(123)).toBeUndefined()
+      expect(guardsAPISpy).toHaveReturnedWith(true)
+    })
+
+    it('例外を投げる', () => {
+      expect(() => assertion(NaN)).toThrowError('value is not a strict number')
+    })
+  })
+
   describe('isString()', () => {
     beforeAll(() => {
       assertion = createAssertion(Asserts.isString)
@@ -775,10 +809,10 @@ describe('Asserts API', () => {
     })
   })
 
-  describe('isMap()', () => {
+  describe('isValidDate()', () => {
     beforeAll(() => {
-      assertion = createAssertion(Asserts.isMap)
-      guardsAPISpy = jest.spyOn(Guards, 'isMap')
+      assertion = createAssertion(Asserts.isValidDate)
+      guardsAPISpy = jest.spyOn(Guards, 'isValidDate')
     })
 
     beforeEach(() => {
@@ -789,25 +823,23 @@ describe('Asserts API', () => {
       guardsAPISpy.mockRestore()
     })
 
-    it('`Guards.isMap()` を呼び出す', () => {
-      const expected = new Map()
+    it('`Guards.isValidDate()` を呼び出す', () => {
+      const date = new Date('2020-10-10')
 
-      assertion(expected)
-      expect(guardsAPISpy).toHaveBeenCalledWith(expected)
+      assertion(date)
+      expect(guardsAPISpy).toHaveBeenCalledWith(date)
     })
 
-    it.each([new Map()])('チェックをパスする', map => {
-      expect(() => assertion(map)).not.toThrowError()
-      expect(guardsAPISpy).toHaveReturnedWith(true)
-    })
+    it.each([new Date(), new Date('2020-10-10')])(
+      '%o => `void` を返す',
+      value => {
+        expect(() => assertion(value)).not.toThrowError()
+        expect(guardsAPISpy).toHaveReturnedWith(true)
+      }
+    )
 
-    it.each([
-      Object.create(null), // dictionary
-      new Set(),
-      new WeakMap(),
-      null
-    ])('例外を投げる', value => {
-      expect(() => assertion(value)).toThrowError('value is not a Map')
+    it.each([new Date('20201010'), null])('%o => 例外を投げる', value => {
+      expect(() => assertion(value)).toThrowError('value is not a valid Date')
       expect(guardsAPISpy).toHaveReturnedWith(false)
     })
   })
@@ -846,38 +878,6 @@ describe('Asserts API', () => {
       null
     ])('例外を投げる', value => {
       expect(() => assertion(value)).toThrowError('value is not a WeakMap')
-      expect(guardsAPISpy).toHaveReturnedWith(false)
-    })
-  })
-
-  describe('isSet()', () => {
-    beforeAll(() => {
-      assertion = createAssertion(Asserts.isSet)
-      guardsAPISpy = jest.spyOn(Guards, 'isSet')
-    })
-
-    beforeEach(() => {
-      guardsAPISpy.mockClear()
-    })
-
-    afterAll(() => {
-      guardsAPISpy.mockRestore()
-    })
-
-    it('`Guards.isSet()` を呼び出す', () => {
-      const expected = new Set()
-
-      assertion(expected)
-      expect(guardsAPISpy).toHaveBeenCalledWith(expected)
-    })
-
-    it.each([new Set()])('チェックをパスする', value => {
-      expect(() => assertion(value)).not.toThrowError()
-      expect(guardsAPISpy).toHaveReturnedWith(true)
-    })
-
-    it.each([[], new WeakSet(), null])('例外を投げる', value => {
-      expect(() => assertion(value)).toThrowError('value is not a Set')
       expect(guardsAPISpy).toHaveReturnedWith(false)
     })
   })

--- a/__tests__/asserts.spec.ts
+++ b/__tests__/asserts.spec.ts
@@ -4,7 +4,7 @@ import Guards from '../src/guards'
 describe('Asserts API', () => {
   const createAssertion = (assertion: (value: unknown) => void) => (
     value: unknown
-  ) => assertion(value)
+  ): void => assertion(value)
   let assertion: ReturnType<typeof createAssertion>
   let guardsAPISpy: jest.SpyInstance
 
@@ -521,7 +521,9 @@ describe('Asserts API', () => {
       expect(() => assertion(promise)).not.toThrowError()
       expect(guardsAPISpy).toHaveReturnedWith(true)
 
-      promise.catch(() => {}) // UnhandledPromiseRejectionWarning の警告が出るため catch してる風を装う(謎)
+      promise.catch((): void => {
+        return undefined
+      }) // UnhandledPromiseRejectionWarning の警告が出るため catch してる風を装う(謎)
     })
 
     it.each([
@@ -585,7 +587,9 @@ describe('Asserts API', () => {
       expect(() => assertion(promiseLike)).not.toThrowError()
       expect(guardsAPISpy).toHaveReturnedWith(true)
 
-      promiseLike.then(null, () => {}) // UnhandledPromiseRejectionWarning の警告が出るため catch してる風を装う(謎)
+      promiseLike.then(null, (): void => {
+        return undefined
+      }) // UnhandledPromiseRejectionWarning の警告が出るため catch してる風を装う(謎)
     })
 
     it.each([null])('例外を投げる', value => {

--- a/__tests__/guards.spec.ts
+++ b/__tests__/guards.spec.ts
@@ -405,7 +405,9 @@ describe('Guards API', () => {
     ])('`true` を返す', promise => {
       expect(Guards.isPromise(promise)).toBe(true)
 
-      promise.catch(() => {}) // UnhandledPromiseRejectionWarning の警告が出るため catch してる風を装う(謎)
+      promise.catch((): void => {
+        return undefined
+      }) // UnhandledPromiseRejectionWarning の警告が出るため catch してる風を装う(謎)
     })
 
     it.each([
@@ -449,7 +451,9 @@ describe('Guards API', () => {
     ])('`true` を返す', promise => {
       expect(Guards.isPromiseLike(promise)).toBe(true)
 
-      promise.then(null, () => {}) // UnhandledPromiseRejectionWarning の警告が出るため catch してる風を装う(謎)
+      promise.then(null, (): void => {
+        return undefined
+      }) // UnhandledPromiseRejectionWarning の警告が出るため catch してる風を装う(謎)
     })
 
     it.each([null])('`false` を返す', value => {

--- a/__tests__/guards.spec.ts
+++ b/__tests__/guards.spec.ts
@@ -96,23 +96,6 @@ describe('Guards API', () => {
     })
   })
 
-  describe('isValidDate()', () => {
-    it('`getObjectTypeName()` を呼び出す', () => {
-      const date = new Date('2020-10-10')
-      Guards.isDate(date)
-      expect(getObjectTypeNameSpy).toBeCalledWith(date)
-    })
-
-    it('`true` を返す', () => {
-      expect(Guards.isValidDate(new Date('2020-10-10'))).toBe(true)
-    })
-
-    it('`false` を返す', () => {
-      expect(Guards.isValidDate(new Date('20201010'))).toBe(false)
-      expect(Guards.isValidDate(null)).toBe(false)
-    })
-  })
-
   describe('isError()', () => {
     it('`getObjectTypeName()` を呼び出す', () => {
       const error = new Error()
@@ -159,6 +142,55 @@ describe('Guards API', () => {
     })
   })
 
+  describe('isFunction()', () => {
+    it('`getObjectTypeName()` を呼び出す', () => {
+      const fn = (): number => 42
+
+      Guards.isFunction(fn)
+      expect(getObjectTypeNameSpy).toBeCalledWith(fn)
+    })
+
+    it.each([
+      (): number => 42,
+      // eslint-disable-next-line no-new-func
+      new Function('return 42')
+    ])('`true` を返す', value => {
+      expect(Guards.isFunction(value)).toBe(true)
+    })
+
+    it.each([
+      function*(): Generator<number, void> {
+        yield 42
+      },
+      null
+    ])('`false` を返す', value => {
+      expect(Guards.isFunction(value)).toBe(false)
+    })
+  })
+
+  describe('isGeneratorFunction()', () => {
+    it('`getObjectTypeName()` を呼び出す', () => {
+      function* fn(): Generator<number, void> {
+        yield 42
+      }
+
+      Guards.isGeneratorFunction(fn)
+      expect(getObjectTypeNameSpy).toBeCalledWith(fn)
+    })
+
+    it.each([
+      function* fn(): Generator<number, void> {
+        yield 42
+      }
+    ])('`true` を返す', value => {
+      expect(Guards.isGeneratorFunction(value)).toBe(true)
+    })
+
+    it.each([(): number => 42, null])('`false` を返す', value => {
+      expect(Guards.isGeneratorFunction(value)).toBe(false)
+    })
+  })
+
   describe('isInteger()', () => {
     it('`Guards.isNumber() を呼び出す`', () => {
       const isNumberSpy = jest.spyOn(Guards, 'isNumber')
@@ -189,6 +221,28 @@ describe('Guards API', () => {
       expect(Guards.isInteger(-Infinity)).toBe(false)
       expect(Guards.isInteger('10')).toBe(false)
       expect(Guards.isInteger(null)).toBe(false)
+    })
+  })
+
+  describe('isMap()', () => {
+    it('`getObjectTypeName()` を呼び出す', () => {
+      const expected = new Map()
+
+      Guards.isMap(expected)
+      expect(getObjectTypeNameSpy).toBeCalledWith(expected)
+    })
+
+    it.each([new Map()])('`true` を返す', map => {
+      expect(Guards.isMap(map)).toBe(true)
+    })
+
+    it.each([
+      Object.create(null), // dictionary
+      new Set(),
+      new WeakMap(),
+      null
+    ])('`false` を返す', value => {
+      expect(Guards.isMap(value)).toBe(false)
     })
   })
 
@@ -243,33 +297,6 @@ describe('Guards API', () => {
     it('`false` を返す', () => {
       expect(Guards.isNumber(null)).toBe(false)
       expect(Guards.isNumber('123')).toBe(false)
-    })
-  })
-
-  describe('isStrictNumber()', () => {
-    it('`Guards.isNumber() を呼び出す`', () => {
-      const isNumberSpy = jest.spyOn(Guards, 'isNumber')
-      Guards.isStrictNumber(123)
-      expect(isNumberSpy).toBeCalledWith(123)
-      isNumberSpy.mockRestore()
-    })
-
-    it('`Guards.isNaN() を呼び出す`', () => {
-      const isNaNSpy = jest.spyOn(Guards, 'isNaN')
-      Guards.isStrictNumber(123)
-      expect(isNaNSpy).toBeCalledWith(123)
-      isNaNSpy.mockRestore()
-    })
-
-    it('`true` を返す', () => {
-      expect(Guards.isStrictNumber(123)).toBe(true)
-      expect(Guards.isStrictNumber(new Number(123))).toBe(true) // eslint-disable-line no-new-wrappers
-    })
-
-    it('`false` を返す', () => {
-      expect(Guards.isStrictNumber(NaN)).toBe(false)
-      expect(Guards.isStrictNumber(null)).toBe(false)
-      expect(Guards.isStrictNumber('123')).toBe(false)
     })
   })
 
@@ -360,55 +387,6 @@ describe('Guards API', () => {
       new DummyClassForIsPlaneObjectTesting()
     ])('`false` を返す', value => {
       expect(Guards.isPlainObject(value)).toBe(false)
-    })
-  })
-
-  describe('isFunction()', () => {
-    it('`getObjectTypeName()` を呼び出す', () => {
-      const fn = (): number => 42
-
-      Guards.isFunction(fn)
-      expect(getObjectTypeNameSpy).toBeCalledWith(fn)
-    })
-
-    it.each([
-      (): number => 42,
-      // eslint-disable-next-line no-new-func
-      new Function('return 42')
-    ])('`true` を返す', value => {
-      expect(Guards.isFunction(value)).toBe(true)
-    })
-
-    it.each([
-      function*(): Generator<number, void> {
-        yield 42
-      },
-      null
-    ])('`false` を返す', value => {
-      expect(Guards.isFunction(value)).toBe(false)
-    })
-  })
-
-  describe('isGeneratorFunction()', () => {
-    it('`getObjectTypeName()` を呼び出す', () => {
-      function* fn(): Generator<number, void> {
-        yield 42
-      }
-
-      Guards.isGeneratorFunction(fn)
-      expect(getObjectTypeNameSpy).toBeCalledWith(fn)
-    })
-
-    it.each([
-      function* fn(): Generator<number, void> {
-        yield 42
-      }
-    ])('`true` を返す', value => {
-      expect(Guards.isGeneratorFunction(value)).toBe(true)
-    })
-
-    it.each([(): number => 42, null])('`false` を返す', value => {
-      expect(Guards.isGeneratorFunction(value)).toBe(false)
     })
   })
 
@@ -529,6 +507,50 @@ describe('Guards API', () => {
     })
   })
 
+  describe('isSet()', () => {
+    it('`getObjectTypeName()` を呼び出す', () => {
+      const expected = new Set()
+
+      Guards.isSet(expected)
+      expect(getObjectTypeNameSpy).toBeCalledWith(expected)
+    })
+
+    it.each([new Set()])('`true` を返す', value => {
+      expect(Guards.isSet(value)).toBe(true)
+    })
+
+    it.each([[], new WeakSet(), null])('`false` を返す', value => {
+      expect(Guards.isSet(value)).toBe(false)
+    })
+  })
+
+  describe('isStrictNumber()', () => {
+    it('`Guards.isNumber() を呼び出す`', () => {
+      const isNumberSpy = jest.spyOn(Guards, 'isNumber')
+      Guards.isStrictNumber(123)
+      expect(isNumberSpy).toBeCalledWith(123)
+      isNumberSpy.mockRestore()
+    })
+
+    it('`Guards.isNaN() を呼び出す`', () => {
+      const isNaNSpy = jest.spyOn(Guards, 'isNaN')
+      Guards.isStrictNumber(123)
+      expect(isNaNSpy).toBeCalledWith(123)
+      isNaNSpy.mockRestore()
+    })
+
+    it('`true` を返す', () => {
+      expect(Guards.isStrictNumber(123)).toBe(true)
+      expect(Guards.isStrictNumber(new Number(123))).toBe(true) // eslint-disable-line no-new-wrappers
+    })
+
+    it('`false` を返す', () => {
+      expect(Guards.isStrictNumber(NaN)).toBe(false)
+      expect(Guards.isStrictNumber(null)).toBe(false)
+      expect(Guards.isStrictNumber('123')).toBe(false)
+    })
+  })
+
   describe('isString()', () => {
     it('`getObjectTypeName()` を呼び出す', () => {
       const expected = 'string'
@@ -571,25 +593,20 @@ describe('Guards API', () => {
     })
   })
 
-  describe('isMap()', () => {
+  describe('isValidDate()', () => {
     it('`getObjectTypeName()` を呼び出す', () => {
-      const expected = new Map()
-
-      Guards.isMap(expected)
-      expect(getObjectTypeNameSpy).toBeCalledWith(expected)
+      const date = new Date('2020-10-10')
+      Guards.isDate(date)
+      expect(getObjectTypeNameSpy).toBeCalledWith(date)
     })
 
-    it.each([new Map()])('`true` を返す', map => {
-      expect(Guards.isMap(map)).toBe(true)
+    it('`true` を返す', () => {
+      expect(Guards.isValidDate(new Date('2020-10-10'))).toBe(true)
     })
 
-    it.each([
-      Object.create(null), // dictionary
-      new Set(),
-      new WeakMap(),
-      null
-    ])('`false` を返す', value => {
-      expect(Guards.isMap(value)).toBe(false)
+    it('`false` を返す', () => {
+      expect(Guards.isValidDate(new Date('20201010'))).toBe(false)
+      expect(Guards.isValidDate(null)).toBe(false)
     })
   })
 
@@ -613,23 +630,6 @@ describe('Guards API', () => {
       null
     ])('`false` を返す', value => {
       expect(Guards.isWeakMap(value)).toBe(false)
-    })
-  })
-
-  describe('isSet()', () => {
-    it('`getObjectTypeName()` を呼び出す', () => {
-      const expected = new Set()
-
-      Guards.isSet(expected)
-      expect(getObjectTypeNameSpy).toBeCalledWith(expected)
-    })
-
-    it.each([new Set()])('`true` を返す', value => {
-      expect(Guards.isSet(value)).toBe(true)
-    })
-
-    it.each([[], new WeakSet(), null])('`false` を返す', value => {
-      expect(Guards.isSet(value)).toBe(false)
     })
   })
 

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -43,15 +43,6 @@ export const Asserts = {
   },
 
   /**
-   * 値が有効なDateかアサートする
-   * @param value
-   * @throw `value` が有効なDateでない
-   */
-  isValidDate(value: unknown): asserts value is Date {
-    assert(Guards.isValidDate(value), 'value is not a valid Date')
-  },
-
-  /**
    * 値がErrorかアサートする
    * @param value
    * @throw `value` がErrorでない
@@ -70,12 +61,42 @@ export const Asserts = {
   },
 
   /**
+   * 値が関数かアサートする
+   * @param value
+   * @throw `value` が関数でない
+   */
+  isFunction(value: unknown): asserts value is Function {
+    return assert(Guards.isFunction(value), 'value is not a function')
+  },
+
+  /**
+   * 値がジェネレーター関数かアサートする
+   * @param value
+   * @throw `value` がジェネレーター関数でない
+   */
+  isGeneratorFunction(value: unknown): asserts value is GeneratorFunction {
+    return assert(
+      Guards.isGeneratorFunction(value),
+      'value is not a generator function'
+    )
+  },
+
+  /**
    * 値が整数かアサートする
    * @param value
    * @throw `value` が整数でない
    */
   isInteger(value: unknown): asserts value is number {
     return assert(Guards.isInteger(value), 'value is not an integer')
+  },
+
+  /**
+   * 値が `Map` かアサートする
+   * @param value
+   * @throw `value` が `Map` でない
+   */
+  isMap(value: unknown): asserts value is Map<unknown, unknown> {
+    assert(Guards.isMap(value), 'value is not a Map')
   },
 
   /**
@@ -106,16 +127,6 @@ export const Asserts = {
   },
 
   /**
-   * 値が厳密に数値かアサートする
-   * @description `NaN` を例外とする
-   * @param value
-   * @throw `value` が厳密に数値でない
-   */
-  isStrictNumber(value: unknown): asserts value is number {
-    return assert(Guards.isStrictNumber(value), 'value is not a strict number')
-  },
-
-  /**
    * 値がビルトインのobjectかアサートする
    * @param value
    * @throw `value` がobjectでない
@@ -131,27 +142,6 @@ export const Asserts = {
    */
   isPlainObject(value: unknown): asserts value is object {
     return assert(Guards.isPlainObject(value), 'value is not a plane object')
-  },
-
-  /**
-   * 値が関数かアサートする
-   * @param value
-   * @throw `value` が関数でない
-   */
-  isFunction(value: unknown): asserts value is Function {
-    return assert(Guards.isFunction(value), 'value is not a function')
-  },
-
-  /**
-   * 値がジェネレーター関数かアサートする
-   * @param value
-   * @throw `value` がジェネレーター関数でない
-   */
-  isGeneratorFunction(value: unknown): asserts value is GeneratorFunction {
-    return assert(
-      Guards.isGeneratorFunction(value),
-      'value is not a generator function'
-    )
   },
 
   /**
@@ -191,6 +181,25 @@ export const Asserts = {
   },
 
   /**
+   * 値が `Set` かアサートする
+   * @param value
+   * @throw `value` が `Set` でない
+   */
+  isSet(value: unknown): asserts value is Set<unknown> {
+    assert(Guards.isSet(value), 'value is not a Set')
+  },
+
+  /**
+   * 値が厳密に数値かアサートする
+   * @description `NaN` を例外とする
+   * @param value
+   * @throw `value` が厳密に数値でない
+   */
+  isStrictNumber(value: unknown): asserts value is number {
+    return assert(Guards.isStrictNumber(value), 'value is not a strict number')
+  },
+
+  /**
    * 値が文字列かアサートする
    * @param value
    * @throw `value` が文字列でない
@@ -218,12 +227,12 @@ export const Asserts = {
   },
 
   /**
-   * 値が `Map` かアサートする
+   * 値が有効なDateかアサートする
    * @param value
-   * @throw `value` が `Map` でない
+   * @throw `value` が有効なDateでない
    */
-  isMap(value: unknown): asserts value is Map<unknown, unknown> {
-    assert(Guards.isMap(value), 'value is not a Map')
+  isValidDate(value: unknown): asserts value is Date {
+    assert(Guards.isValidDate(value), 'value is not a valid Date')
   },
 
   /**
@@ -233,15 +242,6 @@ export const Asserts = {
    */
   isWeakMap(value: unknown): asserts value is WeakMap<object, unknown> {
     assert(Guards.isWeakMap(value), 'value is not a WeakMap')
-  },
-
-  /**
-   * 値が `Set` かアサートする
-   * @param value
-   * @throw `value` が `Set` でない
-   */
-  isSet(value: unknown): asserts value is Set<unknown> {
-    assert(Guards.isSet(value), 'value is not a Set')
   },
 
   /**

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -51,15 +51,6 @@ export const Guards = {
   },
 
   /**
-   * 値が有効なDateか否かを返す
-   * @param value
-   */
-  isValidDate(value: unknown): value is Date {
-    // Invalid Date の getTime の返り値は NaN。 なので返り値が NaN ではない場合は有効なDateとみなす。
-    return Guards.isDate(value) && !Guards.isNaN(value.getTime())
-  },
-
-  /**
    * 値がErrorか否かを返す
    * @param value
    */
@@ -77,12 +68,36 @@ export const Guards = {
   },
 
   /**
+   * 値が関数か否かを返す
+   * @param value
+   */
+  isFunction(value: unknown): value is Function {
+    return getObjectTypeName(value) === '[object Function]'
+  },
+
+  /**
+   * 値がジェネレーター関数か否かを返す
+   * @param value
+   */
+  isGeneratorFunction(value: unknown): value is GeneratorFunction {
+    return getObjectTypeName(value) === '[object GeneratorFunction]'
+  },
+
+  /**
    * 値が整数か否かを返す
    * @alias `Number.isInteger()`
    * @param value
    */
   isInteger(value: unknown): value is number {
     return Guards.isNumber(value) && Number.isInteger(value)
+  },
+
+  /**
+   * 値が `Map` か否かを返す
+   * @param value
+   */
+  isMap(value: unknown): value is Map<unknown, unknown> {
+    return getObjectTypeName(value) === '[object Map]'
   },
 
   /**
@@ -112,15 +127,6 @@ export const Guards = {
   },
 
   /**
-   * 値が厳密に数値か否かを返す
-   * @description `NaN` を `false` とする
-   * @param value
-   */
-  isStrictNumber(value: unknown): value is number {
-    return Guards.isNumber(value) && !Guards.isNaN(value)
-  },
-
-  /**
    * 値がobjectか否かを返す
    * @description `null` 及びプリミティブ値以外をすべて `true` とする
    * @param value
@@ -140,22 +146,6 @@ export const Guards = {
       getObjectTypeName(value) === '[object Object]' &&
       value.constructor === Object.prototype.constructor // constructor を比較してカスタムクラスを弾く
     )
-  },
-
-  /**
-   * 値が関数か否かを返す
-   * @param value
-   */
-  isFunction(value: unknown): value is Function {
-    return getObjectTypeName(value) === '[object Function]'
-  },
-
-  /**
-   * 値がジェネレーター関数か否かを返す
-   * @param value
-   */
-  isGeneratorFunction(value: unknown): value is GeneratorFunction {
-    return getObjectTypeName(value) === '[object GeneratorFunction]'
   },
 
   /**
@@ -196,6 +186,23 @@ export const Guards = {
   },
 
   /**
+   * 値が `Set` か否かを返す
+   * @param value
+   */
+  isSet(value: unknown): value is Set<unknown> {
+    return getObjectTypeName(value) === '[object Set]'
+  },
+
+  /**
+   * 値が厳密に数値か否かを返す
+   * @description `NaN` を `false` とする
+   * @param value
+   */
+  isStrictNumber(value: unknown): value is number {
+    return Guards.isNumber(value) && !Guards.isNaN(value)
+  },
+
+  /**
    * 値が文字列か否かを返す
    * @param value
    */
@@ -220,11 +227,12 @@ export const Guards = {
   },
 
   /**
-   * 値が `Map` か否かを返す
+   * 値が有効なDateか否かを返す
    * @param value
    */
-  isMap(value: unknown): value is Map<unknown, unknown> {
-    return getObjectTypeName(value) === '[object Map]'
+  isValidDate(value: unknown): value is Date {
+    // Invalid Date の getTime の返り値は NaN。 なので返り値が NaN ではない場合は有効なDateとみなす。
+    return Guards.isDate(value) && !Guards.isNaN(value.getTime())
   },
 
   /**
@@ -233,14 +241,6 @@ export const Guards = {
    */
   isWeakMap(value: unknown): value is WeakMap<object, unknown> {
     return getObjectTypeName(value) === '[object WeakMap]'
-  },
-
-  /**
-   * 値が `Set` か否かを返す
-   * @param value
-   */
-  isSet(value: unknown): value is Set<unknown> {
-    return getObjectTypeName(value) === '[object Set]'
   },
 
   /**


### PR DESCRIPTION
#7 

- [x] ESLintの `sort-keys` を有効にする
- [x] メソッドをアルファベット順にソートする
- [x] ついでに ESLint の error と warning に対応